### PR TITLE
Feat/#20: 팝업 모달 구현

### DIFF
--- a/src/components/modal/ModalPortal.tsx
+++ b/src/components/modal/ModalPortal.tsx
@@ -1,0 +1,12 @@
+import ReactDOM from "react-dom";
+
+interface ModalPortalProps {
+  children: React.ReactNode;
+}
+
+const ModalPortal = ({ children }: ModalPortalProps) => {
+  const el = document.getElementById("root") as HTMLElement;
+  return ReactDOM.createPortal(children, el);
+};
+
+export default ModalPortal;

--- a/src/components/modal/Popup.tsx
+++ b/src/components/modal/Popup.tsx
@@ -76,7 +76,7 @@ const PopupWrapper = styled.div`
 
 const PopupContainer = styled.div`
   width: 354px;
-  background-color: white;
+  background-color: var(--white);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -94,15 +94,14 @@ const ButtonGroup = styled.div`
     height: 48px;
     ${typography.title_02}
     border-radius: 8px;
-    border: 1px solid #2f3036;
     width: 100%;
   }
   .cancel-button {
     opacity: 0.4;
-    border: 1px solid #2f3036;
+    border: 1px solid var(--primary-color);
   }
   .confirm-button {
-    background: #2f3036;
+    background: var(--primary-color);
     color: white;
   }
 `;

--- a/src/components/modal/Popup.tsx
+++ b/src/components/modal/Popup.tsx
@@ -1,0 +1,110 @@
+import styled from "styled-components";
+import ModalPortal from "./ModalPortal";
+import { typography } from "../../style/typography";
+
+interface PopupProps {
+  title: string;
+  message: string;
+  closePopup: () => void;
+  type: "confirm" | "alert";
+}
+
+const Popup = ({ title, message, closePopup, type }: PopupProps) => {
+  const renderButtons = () => {
+    switch (type) {
+      case "confirm":
+        return (
+          <>
+            <button
+              type='button'
+              className='cancel-button'
+              onClick={closePopup}>
+              취소
+            </button>
+            <button
+              type='button'
+              className='confirm-button'
+              onClick={closePopup}>
+              확인
+            </button>
+          </>
+        );
+      case "alert":
+        return (
+          <button type='button' className='confirm-button' onClick={closePopup}>
+            확인
+          </button>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <ModalPortal>
+      <PopupWrapper onClick={closePopup}>
+        <PopupContainer onClick={(e) => e.stopPropagation()}>
+          <h1 className='title'>{title}</h1>
+          <p className='message'>{message}</p>
+          <ButtonGroup>{renderButtons()}</ButtonGroup>
+        </PopupContainer>
+      </PopupWrapper>
+    </ModalPortal>
+  );
+};
+
+const PopupWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.5);
+
+  .title {
+    ${typography.headline}
+  }
+  .message {
+    margin-top: 8px;
+    ${typography.body_long_02}
+  }
+`;
+
+const PopupContainer = styled.div`
+  width: 354px;
+  background-color: white;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 20px;
+`;
+
+const ButtonGroup = styled.div`
+  margin-top: 24px;
+  gap: 12px;
+  display: flex;
+  width: 100%;
+  button {
+    width: 151px;
+    height: 48px;
+    ${typography.title_02}
+    border-radius: 8px;
+    border: 1px solid #2f3036;
+    width: 100%;
+  }
+  .cancel-button {
+    opacity: 0.4;
+    border: 1px solid #2f3036;
+  }
+  .confirm-button {
+    background: #2f3036;
+    color: white;
+  }
+`;
+
+export default Popup;

--- a/src/hooks/usePopup.tsx
+++ b/src/hooks/usePopup.tsx
@@ -1,0 +1,40 @@
+import { useCallback, useState } from "react";
+import Popup from "../components/modal/Popup";
+
+export const usePopup = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openPopup = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const closePopup = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const PopupComponent = useCallback(
+    ({
+      title,
+      message,
+      type,
+    }: {
+      title: string;
+      message: string;
+      type: "confirm" | "alert";
+    }) => (
+      <Popup
+        title={title}
+        message={message}
+        closePopup={closePopup}
+        type={type as "confirm" | "alert"}
+      />
+    ),
+    [closePopup],
+  );
+
+  return {
+    Popup: PopupComponent,
+    openPopup,
+    isOpen,
+  };
+};


### PR DESCRIPTION
## 🤷‍♂️ Description

공통으로 사용 할 수 있는 팝업을 구현하였습니다.

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] createPortal 컴포넌트 추가
- [x] Popup.tsx 컴포넌트 구현
- [x] usePopup 훅 구현

## 📷 Screenshots
예시코드 입니다

- title, message에 팝업의 내용들이 들어갑니다
- type은 confirm, alert에 따라 버튼의 수만 렌더링 다르게 하였습니다
- **현재는 취소,확인 클릭 시 모달을 둘다 닫는 이벤트만 추가했습니다. 그리고 모달 바깥 클릭 시 꺼질 수 있도록 하였습니다**

```tsx
import styled from "styled-components";
import { usePopup } from "../hooks/usePopup";

const Home = () => {
  const { Popup, isOpen, openPopup } = usePopup();

  const handleClick = () => {
    openPopup();
  };

  return (
    <>
      {isOpen && <Popup title='제목' message='내용' type='alert' />}
      <HomeStyle>
        <span>Home</span>
        <button type='button' onClick={handleClick}>
          팝업
        </button>
      </HomeStyle>
    </>
  );
};

const HomeStyle = styled.div`
  background-color: orange;
`;

export default Home;
```
<img width="631" alt="스크린샷 2024-08-06 오후 4 38 57" src="https://github.com/user-attachments/assets/7c1df362-824c-470b-9565-d9c00f35a3b9">

<img width="631" alt="스크린샷 2024-08-06 오후 4 41 26" src="https://github.com/user-attachments/assets/2979a2ac-f5b5-4f4f-ab92-e91b30d14a98">

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

closes #20 

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
