### PR TITLE
Feat/#50 팀 별 테마 ThemeContextProvider 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import Signup from "./pages/Signup";
 import Login from "./pages/Login";
 import { typography } from "./style/typography";
 import PasswordReset from "./pages/PasswordReset";
-// import { ThemeProvider } from "styled-components";
+import { ThemeContextProvider } from "./context/ThemeContext";
 
 const queryClient = new QueryClient();
 
@@ -74,7 +74,9 @@ const router = createBrowserRouter([
 const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <ThemeContextProvider>
+        <RouterProvider router={router} />
+      </ThemeContextProvider>
     </QueryClientProvider>
   );
 };

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -63,10 +63,10 @@ const IconWrapper = styled.div<IconProps>`
     isActive
       ? css`
           ${typography.title_01}
-          color:var(--primary-color);
+          color: ${({ theme }) => theme.colors.primary};
           svg {
-            stroke: var(--primary-color);
-            fill: var(--primary-color);
+            stroke: ${({ theme }) => theme.colors.primary};
+            fill: ${({ theme }) => theme.colors.primary};
           }
         `
       : css`

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,31 @@
+/* eslint-disable react/jsx-no-constructed-context-values */
+import { createContext, ReactNode, useState } from "react";
+import { ThemeProvider } from "styled-components";
+import { GlobalStyle } from "../style/global";
+import { getTheme } from "../style/theme";
+
+export const state = {
+  themeName: "",
+};
+
+export const ThemeContext = createContext(state);
+
+export const ThemeContextProvider = ({ children }: { children: ReactNode }) => {
+  const [themeName, setThemeName] = useState("NC다이노스");
+
+  // useEffect(() => {
+  //   const theme = localStorage.getItem("theme");
+  //   if (theme) {
+  //     setThemeName(theme);
+  //   }
+  // }, []);
+
+  return (
+    <ThemeContext.Provider value={{ themeName }}>
+      <ThemeProvider theme={getTheme(themeName)}>
+        <GlobalStyle />
+        {children}
+      </ThemeProvider>
+    </ThemeContext.Provider>
+  );
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,11 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
-import { GlobalStyle } from "./style/global";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <GlobalStyle />
     <App />
   </React.StrictMode>,
 );

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -1,0 +1,110 @@
+interface Theme {
+  colors: {
+    primary: string;
+    secondary: string;
+  };
+}
+
+const defaultTheme: Theme = {
+  colors: {
+    primary: "#2F3036",
+    secondary: "",
+  },
+};
+
+const lgTwins: Theme = {
+  colors: {
+    primary: "#C40037",
+    secondary: "#000000",
+  },
+};
+
+const doosanBears: Theme = {
+  colors: {
+    primary: "#131230",
+    secondary: "#C40037",
+  },
+};
+
+const ssgLanders: Theme = {
+  colors: {
+    primary: "#BE262C",
+    secondary: "#FFD86C",
+  },
+};
+
+const ktWiz: Theme = {
+  colors: {
+    primary: "#000000",
+    secondary: "#EF1925",
+  },
+};
+
+const hanwhaEagles: Theme = {
+  colors: {
+    primary: "#FF6600",
+    secondary: "#25282A",
+  },
+};
+
+const ncDinos: Theme = {
+  colors: {
+    primary: "#1D467D",
+    secondary: "#BEA079",
+  },
+};
+
+const lotteGiants: Theme = {
+  colors: {
+    primary: "#041E42",
+    secondary: "#D00F31",
+  },
+};
+
+const kiaTigers: Theme = {
+  colors: {
+    primary: "#EC0029",
+    secondary: "#05141F",
+  },
+};
+
+const kiwoomHeroes: Theme = {
+  colors: {
+    primary: "#620015",
+    secondary: "#D1187D",
+  },
+};
+
+const samsungLions: Theme = {
+  colors: {
+    primary: "#0059A6",
+    secondary: "#AEAEAF",
+  },
+};
+
+export const getTheme = (team: string) => {
+  switch (team) {
+    case "LG트윈스":
+      return lgTwins;
+    case "두산베어스":
+      return doosanBears;
+    case "SSG랜더스":
+      return ssgLanders;
+    case "KT위즈":
+      return ktWiz;
+    case "한화이글스":
+      return hanwhaEagles;
+    case "NC다이노스":
+      return ncDinos;
+    case "롯데자이언츠":
+      return lotteGiants;
+    case "KIA타이거즈":
+      return kiaTigers;
+    case "키움히어로즈":
+      return kiwoomHeroes;
+    case "삼성라이온즈":
+      return samsungLions;
+    default:
+      return defaultTheme;
+  }
+};


### PR DESCRIPTION
## 🤷‍♂️ Description
팀 별 ThemeContextProvider 이용해서 테마를 추가하였습니다
스프린트 때, 배웠던 테마 적용법 그대로 가져왔습니다. 좀 더 좋은 방법 있으면 의견 내주세요..!
footer에는 테마 컬러를 적용 시켜놨습니다

그리고 유저 로그인 시, 응원팀을 로컬에 저장하는 방법을 생각을 해놨는데 이 부분에 대해서도 논의가 필요 할 것 같습니다.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [ ] ThemeContextProvider 추가
- [ ] 응원팀 테마 전역으로 사용할 수 있도록 추가


## 📷 Screenshots
<img width="501" alt="스크린샷 2024-08-11 오전 1 18 34" src="https://github.com/user-attachments/assets/b5d5326d-1c7e-42c0-963e-9ccba6199f67">
<img width="475" alt="스크린샷 2024-08-11 오전 1 19 01" src="https://github.com/user-attachments/assets/15b5e5d1-cc69-4234-9a9e-a257271ee13f">

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
