### PR TITLE
Feat/#46 유저 인증과 관련된 api, axios 인스턴스 생성, 토큰관리

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -60,5 +60,6 @@ module.exports = {
     "jsx-a11y/no-noninteractive-element-interactions": "off",
     "@typescript-eslint/return-await": "off",
     "no-param-reassign": ["error", { props: false }],
+    "no-console": "off",
   },
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -58,6 +58,7 @@ module.exports = {
     "jsx-a11y/alt-text": "off",
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
-
+    "@typescript-eslint/return-await": "off",
+    "no-param-reassign": ["error", { props: false }],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@hookform/resolvers": "^3.9.0",
         "@tanstack/react-query": "^5.51.21",
         "@vitejs/plugin-react": "^4.3.1",
+        "axios": "^1.7.3",
         "eslint-config-airbnb-typescript": "^18.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -19,8 +20,8 @@
         "sanitize.css": "^13.0.0",
         "styled-components": "^6.1.12",
         "vite": "^5.3.4",
-        "zod": "^3.23.8",
         "vite-plugin-svgr": "^4.2.0",
+        "zod": "^3.23.8",
         "zustand": "^4.5.4"
       },
       "devDependencies": {
@@ -1941,6 +1942,11 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1962,6 +1968,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2119,6 +2135,17 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2336,6 +2363,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dir-glob": {
@@ -3370,12 +3405,44 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -4273,6 +4340,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -4677,6 +4763,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@hookform/resolvers": "^3.9.0",
     "@tanstack/react-query": "^5.51.21",
     "@vitejs/plugin-react": "^4.3.1",
+    "axios": "^1.7.3",
     "eslint-config-airbnb-typescript": "^18.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -21,8 +22,8 @@
     "sanitize.css": "^13.0.0",
     "styled-components": "^6.1.12",
     "vite": "^5.3.4",
-    "zod": "^3.23.8",
     "vite-plugin-svgr": "^4.2.0",
+    "zod": "^3.23.8",
     "zustand": "^4.5.4"
   },
   "devDependencies": {

--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -1,0 +1,15 @@
+import axiosInstance from "../axios";
+
+interface EmailCodeRequest {
+  email: string;
+}
+
+export const requestEmailVerificationCode = async (data: EmailCodeRequest) => {
+  try {
+    const response = await axiosInstance.post("/auth/email-code", data);
+    return response.status;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -59,7 +59,7 @@ export const uploadProfileImage = async (formData: FormData) => {
     );
     return response.data.profileImgUrl;
   } catch (error) {
-    console.log(error);
+    console.error(error);
     throw error;
   }
 };

--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -41,3 +41,46 @@ export const verifyEmailCode = async (data: VerifyEmailCodeRequest) => {
     }
   }
 };
+
+interface UploadProfileImageResponse {
+  profileImgUrl: string;
+}
+
+export const uploadProfileImage = async (formData: FormData) => {
+  try {
+    const response = await axiosInstance.post<UploadProfileImageResponse>(
+      "/s3-store/profile",
+      formData,
+      {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      },
+    );
+    return response.data.profileImgUrl;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
+interface NicknameCheckRequest {
+  nickname: string;
+}
+
+interface NicknameCheckResponse {
+  isExist: boolean;
+}
+
+export const checkNicknameAvailability = async (data: NicknameCheckRequest) => {
+  try {
+    const response = await axiosInstance.post<NicknameCheckResponse>(
+      "/users/existed-nickname",
+      data,
+    );
+    return response.data.isExist;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import axiosInstance from "../axios";
 
 interface EmailCodeRequest {
@@ -11,5 +12,32 @@ export const requestEmailVerificationCode = async (data: EmailCodeRequest) => {
   } catch (error) {
     console.error(error);
     throw error;
+  }
+};
+
+interface VerifyEmailCodeRequest {
+  email: string;
+  code: string;
+}
+
+export const verifyEmailCode = async (data: VerifyEmailCodeRequest) => {
+  try {
+    const response = await axiosInstance.post("/auth/verify-email-code", data);
+    return response.status;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response) {
+        switch (error.response.status) {
+          case 401:
+            throw new Error("인증 코드가 틀렸습니다. 다시 시도해 주세요.");
+          case 500:
+            throw new Error(
+              "서버 오류가 발생했습니다. 나중에 다시 시도해 주세요.",
+            );
+          default:
+            throw new Error(`서버 오류 발생`);
+        }
+      }
+    }
   }
 };

--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -104,3 +104,26 @@ export const signUp = async (data: SignUpRequest) => {
     }
   }
 };
+
+interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export const login = async (data: LoginRequest) => {
+  try {
+    const response = await axiosInstance.post("/auth/login", data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response) {
+        switch (error.response.status) {
+          case 401:
+            throw new Error("아이디 또는 비밀번호가 틀렸습니다");
+          default:
+            throw new Error("로그인 중 오류가 발생했습니다.");
+        }
+      }
+    }
+  }
+};

--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -84,3 +84,23 @@ export const checkNicknameAvailability = async (data: NicknameCheckRequest) => {
     throw error;
   }
 };
+
+interface SignUpRequest {
+  email: string;
+  nickname: string;
+  image: string;
+  teamId: number;
+  password: string;
+}
+
+export const signUp = async (data: SignUpRequest) => {
+  try {
+    const response = await axiosInstance.post("/users/signup", data);
+    return response.status;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.error(error);
+      throw error;
+    }
+  }
+};

--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -127,3 +127,29 @@ export const login = async (data: LoginRequest) => {
     }
   }
 };
+
+interface ChangePasswordRequest {
+  email: string;
+  password: string;
+}
+
+export const changePassword = async (data: ChangePasswordRequest) => {
+  try {
+    await axiosInstance.patch("/users/password", data);
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response) {
+        switch (error.response.status) {
+          case 400:
+            throw new Error("해당 이메일로 가입된 계정이 없습니다.");
+          case 500:
+            throw new Error(
+              "서버 오류가 발생했습니다. 나중에 다시 시도해 주세요.",
+            );
+          default:
+            throw new Error("알 수 없는 오류가 발생했습니다.");
+        }
+      }
+    }
+  }
+};

--- a/src/api/authAxios.ts
+++ b/src/api/authAxios.ts
@@ -8,6 +8,7 @@ const authAxiosInstance = axios.create({
   headers: {
     "Content-Type": "application/json",
   },
+  withCredentials: true,
 });
 
 authAxiosInstance.interceptors.request.use(

--- a/src/api/authAxios.ts
+++ b/src/api/authAxios.ts
@@ -1,5 +1,7 @@
 import axios from "axios";
+import { useNavigate } from "react-router-dom";
 import { useAuthStore } from "../store/authStore";
+import axiosInstance from "./axios";
 
 const BASE_URL = import.meta.env.VITE_API_URL;
 
@@ -25,29 +27,27 @@ authAxiosInstance.interceptors.request.use(
 authAxiosInstance.interceptors.response.use(
   (response) => response,
   async (error) => {
-    const originalRequest = error.config;
+    const retryRequest = error.config;
     const { response } = error;
+    const navigate = useNavigate();
 
     if (response && response.status === 401) {
       try {
-        // 리프레시 토큰으로 액세스 토큰을 새로 발급 받습니다.
+        const refreshResponse = await axiosInstance.post(
+          `${BASE_URL}/auth/token/issue`,
+        );
 
-        const refreshResponse = await axios.post(`${BASE_URL}/auth/refresh`);
-
-        // 새 액세스 토큰을 스토어와 로컬스토리지에 저장합니다.
         const newAccessToken = refreshResponse.data.acToken;
         useAuthStore.getState().loginAction(newAccessToken);
 
-        // 원래의 요청을 새 액세스 토큰으로 다시 시도합니다.
-        authAxiosInstance.defaults.headers.Authorization = `Bearer ${newAccessToken}`;
-        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        retryRequest.headers.Authorization = `Bearer ${newAccessToken}`;
 
-        return authAxiosInstance(originalRequest);
-      } catch (refreshError) {
-        // 리프레시 토큰이 만료되었거나 오류 발생 시 로그아웃 처리
+        return authAxiosInstance(retryRequest);
+      } catch (err) {
         // toast.error("로그인 세션이 만료되었습니다. 다시 로그인 해주세요.");
         useAuthStore.getState().logoutAction();
-        return Promise.reject(refreshError);
+        navigate("/");
+        return Promise.reject(err);
       }
     }
 

--- a/src/api/authAxios.ts
+++ b/src/api/authAxios.ts
@@ -1,0 +1,57 @@
+import axios from "axios";
+import { useAuthStore } from "../store/authStore";
+
+const BASE_URL = import.meta.env.VITE_API_URL;
+
+const authAxiosInstance = axios.create({
+  baseURL: BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+authAxiosInstance.interceptors.request.use(
+  (config) => {
+    const { token } = useAuthStore.getState();
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error),
+);
+
+authAxiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+    const { response } = error;
+
+    if (response && response.status === 401) {
+      try {
+        // 리프레시 토큰으로 액세스 토큰을 새로 발급 받습니다.
+
+        const refreshResponse = await axios.post(`${BASE_URL}/auth/refresh`);
+
+        // 새 액세스 토큰을 스토어와 로컬스토리지에 저장합니다.
+        const newAccessToken = refreshResponse.data.acToken;
+        useAuthStore.getState().loginAction(newAccessToken);
+
+        // 원래의 요청을 새 액세스 토큰으로 다시 시도합니다.
+        authAxiosInstance.defaults.headers.Authorization = `Bearer ${newAccessToken}`;
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+
+        return authAxiosInstance(originalRequest);
+      } catch (refreshError) {
+        // 리프레시 토큰이 만료되었거나 오류 발생 시 로그아웃 처리
+        // toast.error("로그인 세션이 만료되었습니다. 다시 로그인 해주세요.");
+        useAuthStore.getState().logoutAction();
+        return Promise.reject(refreshError);
+      }
+    }
+
+    return Promise.reject(error);
+  },
+);
+
+export default authAxiosInstance;

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -7,6 +7,7 @@ const axiosInstance = axios.create({
   headers: {
     "Content-Type": "application/json",
   },
+  withCredentials: true,
 });
 
 export default axiosInstance;

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,0 +1,12 @@
+import axios from "axios";
+
+const BASE_URL = import.meta.env.VITE_API_URL;
+
+const axiosInstance = axios.create({
+  baseURL: BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+export default axiosInstance;

--- a/src/components/common/OTPInput.tsx
+++ b/src/components/common/OTPInput.tsx
@@ -66,8 +66,8 @@ const Container = styled.div`
 `;
 
 const Input = styled.input`
-  width: 60px;
-  height: 60px;
+  width: 70px;
+  height: 70px;
   font-size: 24px;
   text-align: center;
   border: 1px solid #ccc;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -26,8 +26,10 @@ const LayoutConatiner = styled.div`
 
 const MainWrapper = styled.main`
   height: 100vh;
-  padding-top: 60px;
+  /* padding-top: 60px;
   padding-bottom: 60px;
+   */
+  padding: 60px 20px;
 `;
 
 export default Layout;

--- a/src/components/passwordReset/Confirmpassword.tsx
+++ b/src/components/passwordReset/Confirmpassword.tsx
@@ -1,29 +1,37 @@
 import styled from "styled-components";
 import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
 import Button from "../common/Button";
 import InputField from "../common/InputField";
 import TitleSection from "../common/TitleSection";
+import { changePassword } from "../../api/auth/auth.api";
 
 interface ConfirmpasswordProps {
   password: string;
+  email: string;
 }
 interface ResetpasswordFormData {
   password: string;
   confirmPassword: string;
 }
-const Confirmpassword = ({ password }: ConfirmpasswordProps) => {
+const Confirmpassword = ({ password, email }: ConfirmpasswordProps) => {
+  const navigate = useNavigate();
   const { register, watch, handleSubmit, setValue } =
     useForm<ResetpasswordFormData>({
       mode: "onChange",
     });
 
-  const onSubmit = (data: ResetpasswordFormData) => {
-    console.log(data);
+  const onSubmit = async (data: ResetpasswordFormData) => {
+    try {
+      await changePassword({ email, password: data.confirmPassword });
+      alert("비밀번호 변경이 완료되었습니다.");
+      navigate("/login");
+    } catch (err) {
+      console.log(err);
+    }
   };
   const passwordValue = password;
   const confirmPasswordValue = watch("confirmPassword");
-
-  console.log(passwordValue, confirmPasswordValue);
 
   const isButtonDisabled =
     !passwordValue ||

--- a/src/components/passwordReset/EmailValid.tsx
+++ b/src/components/passwordReset/EmailValid.tsx
@@ -6,6 +6,7 @@ import TitleSection from "../common/TitleSection";
 import InputField from "../common/InputField";
 import Button from "../common/Button";
 import { UserInfo } from "../../types/User";
+import { requestEmailVerificationCode } from "../../api/auth/auth.api";
 
 interface EmailValidProps {
   setstep: (step: number) => void;
@@ -20,6 +21,7 @@ const EmailValid = ({ setstep, handleSetUserInfo }: EmailValidProps) => {
     watch,
     handleSubmit,
     setValue,
+    setError,
     formState: { errors },
   } = useForm<FormData>({
     resolver: zodResolver(schema),
@@ -31,10 +33,18 @@ const EmailValid = ({ setstep, handleSetUserInfo }: EmailValidProps) => {
 
   const isButtonDisabled = !emailValue;
 
-  const onSubmit = (data: FormData) => {
-    console.log(data);
-    handleSetUserInfo({ email: data.email });
-    setstep(2);
+  const onSubmit = async (data: FormData) => {
+    try {
+      await requestEmailVerificationCode({ email: data.email });
+      handleSetUserInfo({ email: data.email });
+      setstep(2);
+    } catch (error) {
+      setError("email", {
+        type: "manual",
+        message:
+          "이메일 인증 코드 전송 중 오류가 발생했습니다. 다시 시도해 주세요.",
+      });
+    }
   };
   return (
     <Container>

--- a/src/components/signup/EmailValid.tsx
+++ b/src/components/signup/EmailValid.tsx
@@ -6,6 +6,7 @@ import TitleSection from "../common/TitleSection";
 import InputField from "../common/InputField";
 import Button from "../common/Button";
 import { UserInfo } from "../../types/User";
+import { requestEmailVerificationCode } from "../../api/auth/auth.api";
 
 interface EmailValidProps {
   setstep: (step: number) => void;
@@ -20,6 +21,7 @@ const EmailValid = ({ setstep, handleSetUserInfo }: EmailValidProps) => {
     watch,
     handleSubmit,
     setValue,
+    setError,
     formState: { errors },
   } = useForm<FormData>({
     resolver: zodResolver(schema),
@@ -31,10 +33,18 @@ const EmailValid = ({ setstep, handleSetUserInfo }: EmailValidProps) => {
 
   const isButtonDisabled = !emailValue;
 
-  const onSubmit = (data: FormData) => {
-    console.log(data);
-    handleSetUserInfo({ email: data.email });
-    setstep(2);
+  const onSubmit = async (data: FormData) => {
+    try {
+      await requestEmailVerificationCode({ email: data.email });
+      handleSetUserInfo({ email: data.email });
+      setstep(2);
+    } catch (error) {
+      setError("email", {
+        type: "manual",
+        message:
+          "이메일 인증 코드 전송 중 오류가 발생했습니다. 다시 시도해 주세요.",
+      });
+    }
   };
   return (
     <Container>

--- a/src/components/signup/TeamSelect.tsx
+++ b/src/components/signup/TeamSelect.tsx
@@ -4,9 +4,10 @@ import { useNavigate } from "react-router-dom";
 import TitleSection from "../common/TitleSection";
 import Button from "../common/Button";
 import { UserInfo } from "../../types/User";
+import { signUp } from "../../api/auth/auth.api";
 
 interface Team {
-  id: string;
+  id: number;
   name: string;
   color: string;
   bg: string;
@@ -14,75 +15,76 @@ interface Team {
 }
 
 interface TeamSelectProps {
+  userInfo: UserInfo;
   handleSetUserInfo: (userInfo: Partial<UserInfo>) => void;
 }
 
 const teams: Team[] = [
   {
-    id: "lgtwins",
+    id: 0,
     name: "LG Twins",
     bg: "var(--lg-twins-red)",
     color: "var(--lg-twins-black)",
     borderColor: "transparent",
   },
   {
-    id: "doosanbears",
+    id: 1,
     name: "Doosan Bears",
     bg: "var(--doosan-bears-navy)",
     color: "white",
     borderColor: "var(--doosan-bears-red)",
   },
   {
-    id: "hanwhaeagles",
+    id: 2,
     name: "Hanwha Eagles",
     bg: "var(--hanwha-eagles-black)",
     color: "var(--hanwha-eagles-orange)",
     borderColor: "transparent",
   },
   {
-    id: "samsunglions",
+    id: 3,
     name: "SAMSUNG Lions",
     bg: "var(--samsung-lions-blue)",
     color: "white",
     borderColor: "transparent",
   },
   {
-    id: "ktwiz",
+    id: 4,
     name: "KT Wiz",
     bg: "var(--kt-wiz-black)",
     color: "var(--kt-wiz-red)",
     borderColor: "transparent",
   },
   {
-    id: "ssglanders",
+    id: 5,
     name: "SSG Landers",
     bg: "var(--ssg-landers-red)",
     color: "gold",
     borderColor: "transparent",
   },
   {
-    id: "ncdinos",
+    id: 6,
     name: "NC Dinos",
     bg: "var(--nc-dinos-blue)",
     color: "var(--nc-dinos-gold)",
     borderColor: "transparent",
   },
   {
-    id: "kiatigeres",
+    id: 7,
     name: "KIA Tigers",
     bg: "var(--kia-tigers-black)",
     color: "var(--kia-tigers-red)",
     borderColor: "transparent",
   },
   {
-    id: "lottegiants",
+    id: 8,
     name: "Lotte Giants",
     bg: "var(--lotte-giants-navy)",
     color: "var(--lotte-giants-red)",
     borderColor: "white",
   },
   {
-    id: "kiwoomheroes",
+    id: 9,
     name: "Kiwoom Heroes",
     bg: "var(--kiwoom-heroes-magenta)",
     color: "white",
@@ -90,17 +92,29 @@ const teams: Team[] = [
   },
 ];
 
-const TeamSelect = ({ handleSetUserInfo }: TeamSelectProps) => {
+const TeamSelect = ({ handleSetUserInfo, userInfo }: TeamSelectProps) => {
   const navigate = useNavigate();
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
 
   const handleTeamSelect = (team: Team) => {
     setSelectedTeam(team);
-    handleSetUserInfo({ team: team.name });
+    handleSetUserInfo({ teamId: team.id });
   };
 
-  const handleClick = () => {
-    navigate("/");
+  const handleClick = async () => {
+    try {
+      const data = {
+        email: userInfo.email,
+        nickname: userInfo.nickname,
+        image: userInfo.profilePicture,
+        teamId: selectedTeam!.id,
+        password: userInfo.password,
+      };
+      await signUp(data);
+      navigate("/");
+    } catch (err) {
+      console.log(err);
+    }
   };
 
   return (

--- a/src/components/signup/VerificationCode.tsx
+++ b/src/components/signup/VerificationCode.tsx
@@ -19,6 +19,8 @@ const VerificationCode = ({
 }: VerificationCodeProps) => {
   const [otp, setOtp] = useState(["", "", "", "", ""]);
 
+  const isOtpComplete = otp.every((char) => char.length === 1);
+
   const handleClick = () => {
     console.log(otp.join(""));
     handleSetUserInfo({ verificationCode: otp.join(",") });
@@ -37,7 +39,11 @@ const VerificationCode = ({
       </div>
 
       <ButtonWrapper>
-        <Button type='button' onClick={handleClick} variant='primary'>
+        <Button
+          type='button'
+          onClick={handleClick}
+          variant='primary'
+          disabled={!isOtpComplete}>
           확인
         </Button>
       </ButtonWrapper>

--- a/src/components/signup/VerificationCode.tsx
+++ b/src/components/signup/VerificationCode.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import styled from "styled-components";
 import axios from "axios";
-import { UserInfo } from "../../types/User";
 import OTPInput from "../common/OTPInput";
 import TitleSection from "../common/TitleSection";
 import Button from "../common/Button";
@@ -14,14 +13,9 @@ import {
 interface VerificationCodeProps {
   email: string;
   setstep: (step: number) => void;
-  handleSetUserInfo: (userInfo: Partial<UserInfo>) => void;
 }
 
-const VerificationCode = ({
-  email,
-  setstep,
-  handleSetUserInfo,
-}: VerificationCodeProps) => {
+const VerificationCode = ({ email, setstep }: VerificationCodeProps) => {
   const [otp, setOtp] = useState(["", "", "", "", ""]);
   const [error, setError] = useState<string | null>(null);
 
@@ -34,7 +28,6 @@ const VerificationCode = ({
       const otpCode = otp.join("");
       await verifyEmailCode({ email, code: otpCode });
 
-      handleSetUserInfo({ verificationCode: otpCode });
       setstep(3);
     } catch (err) {
       if (axios.isAxiosError(err)) {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -38,7 +38,6 @@ const Container = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 20px;
   box-sizing: border-box;
   width: 100%;
   max-width: 480px;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,9 +1,11 @@
 import { useForm } from "react-hook-form";
 import styled from "styled-components";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import Button from "../components/common/Button";
 import TitleSection from "../components/common/TitleSection";
 import InputField from "../components/common/InputField";
+import { login } from "../api/auth/auth.api";
+import { useAuthStore } from "../store/authStore";
 
 interface LoginFormData {
   email: string;
@@ -11,16 +13,32 @@ interface LoginFormData {
 }
 
 const Login = () => {
+  const { loginAction } = useAuthStore();
+  const navigate = useNavigate();
   const {
     register,
     watch,
     handleSubmit,
     setValue,
+    setError,
     formState: { errors },
   } = useForm<LoginFormData>({});
 
-  const onSubmit = (data: LoginFormData) => {
-    console.log(data);
+  const onSubmit = async (data: LoginFormData) => {
+    try {
+      const response = await login(data);
+      if (response.acToken) {
+        loginAction(response.acToken);
+        navigate("/home");
+      }
+    } catch (err) {
+      if (err) {
+        setError("password", {
+          type: "manual",
+          message: "아이디 또는 비밀번호가 틀립니다.",
+        });
+      }
+    }
   };
   const emailValue = watch("email");
   const passwordValue = watch("password");

--- a/src/pages/PasswordReset.tsx
+++ b/src/pages/PasswordReset.tsx
@@ -30,20 +30,14 @@ const PasswordReset = () => {
       case 1:
         return <EmailValid setstep={setstep} handleSetUserInfo={handleInfo} />;
       case 2:
-        return (
-          <VerificationCode
-            email={info.email}
-            setstep={setstep}
-            handleSetUserInfo={handleInfo}
-          />
-        );
+        return <VerificationCode email={info.email} setstep={setstep} />;
 
       case 3:
         return (
           <PasswordValid setstep={setstep} handleSetUserInfo={handleInfo} />
         );
       case 4:
-        return <Confirmpassword password={info.password} />;
+        return <Confirmpassword password={info.password} email={info.email} />;
       default:
         return null;
     }

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -7,7 +7,7 @@ import PasswordValid from "../components/signup/PasswordValid";
 import TeamSelect from "../components/signup/TeamSelect";
 
 const Signup = () => {
-  const [step, setstep] = useState(2);
+  const [step, setstep] = useState(1);
   const [userInfo, setuserInfo] = useState<UserInfo>({
     email: "",
     verificationCode: "",

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -10,11 +10,10 @@ const Signup = () => {
   const [step, setstep] = useState(1);
   const [userInfo, setuserInfo] = useState<UserInfo>({
     email: "",
-    verificationCode: "",
     nickname: "",
     profilePicture: "",
     password: "",
-    team: "",
+    teamId: 0,
   });
 
   const handleSetUserInfo = (updatedUserInfo: Partial<UserInfo>) => {
@@ -31,13 +30,7 @@ const Signup = () => {
           <EmailValid setstep={setstep} handleSetUserInfo={handleSetUserInfo} />
         );
       case 2:
-        return (
-          <VerificationCode
-            email={userInfo.email}
-            setstep={setstep}
-            handleSetUserInfo={handleSetUserInfo}
-          />
-        );
+        return <VerificationCode email={userInfo.email} setstep={setstep} />;
       case 3:
         return (
           <Profile setstep={setstep} handleSetUserInfo={handleSetUserInfo} />
@@ -50,7 +43,12 @@ const Signup = () => {
           />
         );
       case 5:
-        return <TeamSelect handleSetUserInfo={handleSetUserInfo} />;
+        return (
+          <TeamSelect
+            handleSetUserInfo={handleSetUserInfo}
+            userInfo={userInfo}
+          />
+        );
       default:
         return null;
     }

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -7,7 +7,7 @@ import PasswordValid from "../components/signup/PasswordValid";
 import TeamSelect from "../components/signup/TeamSelect";
 
 const Signup = () => {
-  const [step, setstep] = useState(1);
+  const [step, setstep] = useState(2);
   const [userInfo, setuserInfo] = useState<UserInfo>({
     email: "",
     verificationCode: "",

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface StoreState {
+  isLoggedIn: boolean;
+  token: string;
+  loginAction: (token: string) => void;
+  logoutAction: () => void;
+}
+
+export const useAuthStore = create(
+  persist<StoreState>(
+    (set) => ({
+      isLoggedIn: false,
+      token: "",
+      loginAction: (token: string) => {
+        set({ isLoggedIn: true, token });
+      },
+      logoutAction: () => {
+        set({ isLoggedIn: false, token: "" });
+      },
+    }),
+    {
+      name: "auth",
+    },
+  ),
+);

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,8 +1,7 @@
 export interface UserInfo {
   email: string;
-  verificationCode: string;
   nickname: string;
   profilePicture: string;
   password: string;
-  team: string;
+  teamId: number;
 }


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->
유저 인증과 관련된 api, axios 인스턴스 생성, 토큰관리

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [ ] 인증과 관련된 api 구현
- [ ] 리프레쉬 토큰은 쿠키, 액세스토큰은 주스탄드의 persist를 이용하여 로컬스토리지에 저장
- [ ] 인증이 필요한(액세스 토큰을 보내줘야 하는) axios와 인증이 필요없는 axios 인스턴스 생성
- [ ] 인터셉터 로직을 통한 모든 요청전에 액세스 토큰을 꺼내고 만약 이 액세스 토큰이 만료가 됬다면 액세스토큰을 
재발급 받는 로직 추가 , 이 재발급 받은 토큰을 이용하여 기존의 요청은 retry하여 재요청 하게 로직 작성
- [ ]  응원팀 같은 경우는 로그인 성공후 받아서 저장할 예정(이 부분은 아직 미구현, 아직 백엔드 api가 덜 만들어져서 추후 구현 예정)


## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
