### PR TITLE
♻️ 인풋필드 공통컴포넌트 수정

### DIFF
--- a/src/components/common/InputField.tsx
+++ b/src/components/common/InputField.tsx
@@ -7,6 +7,76 @@ import {
   UseFormSetValue,
 } from "react-hook-form";
 
+interface InputFieldProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "name"> {
+  name: string; // name은 필수이므로 여전히 명시적으로 선언
+  label: string;
+  register: UseFormRegister<any>;
+  watch: UseFormWatch<any>;
+  setValue: UseFormSetValue<any>;
+  error?: FieldError;
+  maxLength?: number;
+}
+
+const InputField = ({
+  name,
+  label,
+  type = "text",
+  placeholder,
+  maxLength,
+  register,
+  watch,
+  setValue,
+  error,
+  ...inputProps
+}: InputFieldProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const toggleVisibility = () => setIsVisible(!isVisible);
+
+  const inputType = type === "password" && isVisible ? "text" : type;
+  const data = watch(name) as string;
+  const currentLength = data ? data.length : 0;
+
+  const clearInput = () => {
+    setValue(name, "");
+  };
+
+  return (
+    <InputContainer>
+      <div className='labelWrapper'>
+        <InputLabel htmlFor={name}>{label}</InputLabel>
+        {maxLength && (
+          <CharCount>
+            {currentLength}/{maxLength}
+          </CharCount>
+        )}
+      </div>
+
+      <InputWrapper>
+        <StyledInput
+          id={name}
+          type={inputType}
+          placeholder={placeholder}
+          $hasError={!!error}
+          {...register(name)}
+          {...inputProps}
+        />
+        {data && type !== "password" && (
+          <ClearButton type='button' onClick={clearInput}>
+            ×
+          </ClearButton>
+        )}
+        {type === "password" && (
+          <VisibilityToggle type='button' onClick={toggleVisibility}>
+            {isVisible ? "👁️" : "👁️‍🗨️"}
+          </VisibilityToggle>
+        )}
+      </InputWrapper>
+      {error && <ErrorMessage>{error.message}</ErrorMessage>}
+    </InputContainer>
+  );
+};
+
 const InputContainer = styled.div`
   margin-bottom: 16px;
   position: relative;
@@ -71,80 +141,4 @@ const ClearButton = styled.button`
     color: #666;
   }
 `;
-
-interface InputFieldProps {
-  name: string;
-  label: string;
-  type?: string;
-  placeholder?: string;
-  maxLength?: number;
-  register: UseFormRegister<any>;
-  watch: UseFormWatch<any>;
-  setValue: UseFormSetValue<any>;
-  error?: FieldError;
-  value?: string;
-  disabled?: boolean;
-}
-
-const InputField = ({
-  name,
-  label,
-  type = "text",
-  placeholder,
-  maxLength,
-  register,
-  watch,
-  setValue,
-  error,
-  value,
-  disabled,
-}: InputFieldProps) => {
-  const [isVisible, setIsVisible] = useState(false);
-  const toggleVisibility = () => setIsVisible(!isVisible);
-
-  const inputType = type === "password" && isVisible ? "text" : type;
-  const data = watch(name) as string;
-  const currentLength = data ? data.length : 0;
-
-  const clearInput = () => {
-    setValue(name, "");
-  };
-
-  return (
-    <InputContainer>
-      <div className='labelWrapper'>
-        <InputLabel htmlFor={name}>{label}</InputLabel>
-        {maxLength && (
-          <CharCount>
-            {currentLength}/{maxLength}
-          </CharCount>
-        )}
-      </div>
-
-      <InputWrapper>
-        <StyledInput
-          id={name}
-          type={inputType}
-          value={value}
-          placeholder={placeholder}
-          $hasError={!!error}
-          disabled={disabled}
-          {...register(name)}
-        />
-        {data && type !== "password" && (
-          <ClearButton type='button' onClick={clearInput}>
-            ×
-          </ClearButton>
-        )}
-        {type === "password" && (
-          <VisibilityToggle type='button' onClick={toggleVisibility}>
-            {isVisible ? "👁️" : "👁️‍🗨️"}
-          </VisibilityToggle>
-        )}
-      </InputWrapper>
-      {error && <ErrorMessage>{error.message}</ErrorMessage>}
-    </InputContainer>
-  );
-};
-
 export default InputField;


### PR DESCRIPTION
인풋필드 공통컴포넌트 수정

## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->
인풋필드 공통컴포넌트 수정
## 📝 Primary Commits
어제 멘토링에서 본 코드대로 기본적인 input의 어트리뷰트를 다 상속을 받고 불필요한 타입지정을 줄였습니다
추가로 리액트훅폼에서 명시된 타입으로만 세팅하였습니다
<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [ ] 인풋필드 공통컴포넌트 수정


## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
