### PR TITLE
✨ TextArea 공통컴포넌트 제작

### DIFF
--- a/src/components/common/TextAreaField.tsx
+++ b/src/components/common/TextAreaField.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import styled from "styled-components";
+import {
+  UseFormRegister,
+  FieldError,
+  UseFormWatch,
+  UseFormSetValue,
+} from "react-hook-form";
+
+interface TextAreaFieldProps
+  extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "name"> {
+  name: string;
+  label: string;
+  register: UseFormRegister<any>;
+  watch: UseFormWatch<any>;
+  setValue: UseFormSetValue<any>;
+  error?: FieldError;
+  maxLength?: number;
+}
+
+const TextAreaField = ({
+  name,
+  label,
+  placeholder,
+  maxLength,
+  register,
+  watch,
+  setValue,
+  error,
+  disabled,
+  rows = 2,
+  ...textareaProps
+}: TextAreaFieldProps) => {
+  const data = watch(name) as string;
+
+  const currentLength = data ? data.length : 0;
+
+  return (
+    <InputContainer>
+      <div className='labelWrapper'>
+        <InputLabel htmlFor={name}>{label}</InputLabel>
+        {maxLength && (
+          <CharCount>
+            {currentLength}/{maxLength}
+          </CharCount>
+        )}
+      </div>
+      <InputWrapper>
+        <StyledTextArea
+          id={name}
+          placeholder={placeholder}
+          rows={rows}
+          {...register(name)}
+          {...textareaProps}
+        />
+      </InputWrapper>
+    </InputContainer>
+  );
+};
+
+const InputContainer = styled.div`
+  margin-bottom: 16px;
+  position: relative;
+  .labelWrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+`;
+
+const InputLabel = styled.label`
+  display: block;
+  margin-bottom: 8px;
+  font-weight: bold;
+`;
+
+const InputWrapper = styled.div`
+  position: relative;
+`;
+
+const StyledTextArea = styled.textarea`
+  width: 100%;
+  padding: 8px;
+  outline: none;
+  border: none;
+  border-bottom: 1px solid #ccc;
+  border-radius: 4px;
+  resize: vertical;
+  min-height: 100px;
+`;
+
+const CharCount = styled.span`
+  font-size: 12px;
+  color: #666;
+`;
+
+export default TextAreaField;

--- a/src/components/signup/EmailValid.tsx
+++ b/src/components/signup/EmailValid.tsx
@@ -15,6 +15,7 @@ interface EmailValidProps {
 const schema = z.object({
   email: z.string().email("유효하지 않은 이메일 주소입니다."),
 });
+
 const EmailValid = ({ setstep, handleSetUserInfo }: EmailValidProps) => {
   const {
     register,
@@ -92,4 +93,5 @@ const InputWrapper = styled.div`
 `;
 
 const ButtonWrapper = styled.div``;
+
 export default EmailValid;


### PR DESCRIPTION
TextArea 공통컴포넌트 제작

## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->
TextArea 공통컴포넌트 제작
## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->
리액트 훅폼의 useForm을 만들고 리액트훅폼으로 관리할 폼들을 타입을 지정후 아래와 같이 내려줍니다
그 후에 아래와 같이 등록을 하면 onSubmit의 data에 내가 등록한 폼들에서 입력한 값들이 나옵니다
```
 <TextAreaField
            name='memo' //내가 등록할 폼의 name
            label='메모'
            placeholder='직관 한마디!'
            maxLength={200}
            register={register}
            watch={watch}
            setValue={setValue}
          />
```

- [ ] TextArea 공통컴포넌트 제작


## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->
![image](https://github.com/user-attachments/assets/9bd61d06-88d9-4bd0-a394-eeddc5901220)

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
