### PR TITLE
Feat/#84 오늘의경기 리스트 API 연동

### DIFF
--- a/src/api/game/game.ts
+++ b/src/api/game/game.ts
@@ -1,0 +1,52 @@
+import authAxiosInstance from "../authAxios";
+
+export interface DailyMatchResponse {
+  id: string;
+  date: string;
+  time: string;
+  status: string;
+  homeTeam: {
+    id: number;
+    name: string;
+  };
+  awayTeam: {
+    id: number;
+    name: string;
+  };
+  stadium: {
+    id: number;
+    name: string;
+    latitude: number;
+    longitude: number;
+    address: string;
+  };
+  homeTeamScore: number;
+  awayTeamScore: number;
+  winningTeam: {
+    id: number;
+    name: string;
+  };
+}
+
+export const getDailyMatch = async (
+  year: number,
+  month: number,
+  day: number,
+) => {
+  try {
+    const response = await authAxiosInstance.get<DailyMatchResponse[]>(
+      "/games/daily",
+      {
+        params: {
+          year,
+          month,
+          day,
+        },
+      },
+    );
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/src/components/todayMatch/TodayMatchItem.tsx
+++ b/src/components/todayMatch/TodayMatchItem.tsx
@@ -1,8 +1,9 @@
 import styled from "styled-components";
 import { typography } from "../../style/typography";
+import { DailyMatchResponse } from "../../api/game/game";
 
 interface TodayMatchItemProps {
-  match: any;
+  match: DailyMatchResponse;
 }
 
 const TodayMatchItem = ({ match }: TodayMatchItemProps) => {
@@ -12,10 +13,12 @@ const TodayMatchItem = ({ match }: TodayMatchItemProps) => {
         <div>{match.homeTeam.name}</div>
         <div>{match.awayTeam.name}</div>
       </div>
-      <div className='score'>
-        <div>{match.homeTeamScore}</div>
-        <div>{match.awayTeamScore}</div>
-      </div>
+      {match.status === "경기 종료" && (
+        <div className='score'>
+          <div>{match.homeTeamScore}</div>
+          <div>{match.awayTeamScore}</div>
+        </div>
+      )}
     </TodayMatchItemContainer>
   );
 };
@@ -41,7 +44,7 @@ const TodayMatchItemContainer = styled.div`
   .score {
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     padding: 4px 8px;
     gap: 8px;
     width: 25px;

--- a/src/components/todayMatch/TodayMatchList.tsx
+++ b/src/components/todayMatch/TodayMatchList.tsx
@@ -1,126 +1,133 @@
 import styled from "styled-components";
+import { useQuery } from "@tanstack/react-query";
 import TodayMatchItem from "./TodayMatchItem";
 import { typography } from "../../style/typography";
+import { getDailyMatch } from "../../api/game/game";
 
-const DATA = [
-  {
-    id: 1,
-    date: "2024-08-11T13:00:00Z",
-    time: "13:00",
-    status: "Completed",
-    homeTeam: {
-      id: 101,
-      name: "두산 베어스",
-    },
-    awayTeam: {
-      id: 102,
-      name: "LG 트윈스",
-    },
-    stadium: {
-      id: 201,
-      name: "잠실야구장",
-      latitude: 37.5121,
-      longitude: 127.0726,
-      address: "서울특별시 송파구 올림픽로 25",
-    },
-    homeTeamScore: "4",
-    awayTeamScore: "6",
-    winningTeam: {
-      id: 102,
-      name: "LG 트윈스",
-    },
-  },
-  {
-    id: 2,
-    date: "2024-08-12T18:30:00Z",
-    time: "18:30",
-    status: "Completed",
-    homeTeam: {
-      id: 103,
-      name: "삼성 라이온즈",
-    },
-    awayTeam: {
-      id: 104,
-      name: "KIA 타이거즈",
-    },
-    stadium: {
-      id: 202,
-      name: "대구 삼성 라이온즈 파크",
-      latitude: 35.8078,
-      longitude: 128.5661,
-      address: "대구광역시 북구 대봉로 180",
-    },
-    homeTeamScore: "7",
-    awayTeamScore: "2",
-    winningTeam: {
-      id: 103,
-      name: "삼성 라이온즈",
-    },
-  },
-  {
-    id: 3,
-    date: "2024-08-13T14:00:00Z",
-    time: "14:00",
-    status: "Scheduled",
-    homeTeam: {
-      id: 105,
-      name: "한화 이글스",
-    },
-    awayTeam: {
-      id: 106,
-      name: "롯데 자이언츠",
-    },
-    stadium: {
-      id: 203,
-      name: "대전 한화생명이글스파크",
-      latitude: 36.3171,
-      longitude: 127.4289,
-      address: "대전광역시 중구 대종로 373",
-    },
-    homeTeamScore: "0",
-    awayTeamScore: "0",
-    winningTeam: {
-      id: 0,
-      name: "",
-    },
-  },
-  {
-    id: 3,
-    date: "2024-08-13T14:00:00Z",
-    time: "14:00",
-    status: "Scheduled",
-    homeTeam: {
-      id: 105,
-      name: "한화 이글스",
-    },
-    awayTeam: {
-      id: 106,
-      name: "롯데 자이언츠",
-    },
-    stadium: {
-      id: 203,
-      name: "대전 한화생명이글스파크",
-      latitude: 36.3171,
-      longitude: 127.4289,
-      address: "대전광역시 중구 대종로 373",
-    },
-    homeTeamScore: "0",
-    awayTeamScore: "0",
-    winningTeam: {
-      id: 0,
-      name: "",
-    },
-  },
-];
+// const DATA = [
+//   {
+//     id: 1,
+//     date: "2024-08-11T13:00:00Z",
+//     time: "13:00",
+//     status: "Completed",
+//     homeTeam: {
+//       id: 101,
+//       name: "두산 베어스",
+//     },
+//     awayTeam: {
+//       id: 102,
+//       name: "LG 트윈스",
+//     },
+//     stadium: {
+//       id: 201,
+//       name: "잠실야구장",
+//       latitude: 37.5121,
+//       longitude: 127.0726,
+//       address: "서울특별시 송파구 올림픽로 25",
+//     },
+//     homeTeamScore: "4",
+//     awayTeamScore: "6",
+//     winningTeam: {
+//       id: 102,
+//       name: "LG 트윈스",
+//     },
+//   },
+//   {
+//     id: 2,
+//     date: "2024-08-12T18:30:00Z",
+//     time: "18:30",
+//     status: "Completed",
+//     homeTeam: {
+//       id: 103,
+//       name: "삼성 라이온즈",
+//     },
+//     awayTeam: {
+//       id: 104,
+//       name: "KIA 타이거즈",
+//     },
+//     stadium: {
+//       id: 202,
+//       name: "대구 삼성 라이온즈 파크",
+//       latitude: 35.8078,
+//       longitude: 128.5661,
+//       address: "대구광역시 북구 대봉로 180",
+//     },
+//     homeTeamScore: "7",
+//     awayTeamScore: "2",
+//     winningTeam: {
+//       id: 103,
+//       name: "삼성 라이온즈",
+//     },
+//   },
+//   {
+//     id: 3,
+//     date: "2024-08-13T14:00:00Z",
+//     time: "14:00",
+//     status: "Scheduled",
+//     homeTeam: {
+//       id: 105,
+//       name: "한화 이글스",
+//     },
+//     awayTeam: {
+//       id: 106,
+//       name: "롯데 자이언츠",
+//     },
+//     stadium: {
+//       id: 203,
+//       name: "대전 한화생명이글스파크",
+//       latitude: 36.3171,
+//       longitude: 127.4289,
+//       address: "대전광역시 중구 대종로 373",
+//     },
+//     homeTeamScore: "0",
+//     awayTeamScore: "0",
+//     winningTeam: {
+//       id: 0,
+//       name: "",
+//     },
+//   },
+//   {
+//     id: 3,
+//     date: "2024-08-13T14:00:00Z",
+//     time: "14:00",
+//     status: "Scheduled",
+//     homeTeam: {
+//       id: 105,
+//       name: "한화 이글스",
+//     },
+//     awayTeam: {
+//       id: 106,
+//       name: "롯데 자이언츠",
+//     },
+//     stadium: {
+//       id: 203,
+//       name: "대전 한화생명이글스파크",
+//       latitude: 36.3171,
+//       longitude: 127.4289,
+//       address: "대전광역시 중구 대종로 373",
+//     },
+//     homeTeamScore: "0",
+//     awayTeamScore: "0",
+//     winningTeam: {
+//       id: 0,
+//       name: "",
+//     },
+//   },
+// ];
+
+const DATE = new Date();
 
 const TodayMatchList = () => {
+  const { data } = useQuery({
+    queryKey: ["dailyMatches"],
+    queryFn: () =>
+      getDailyMatch(DATE.getFullYear(), DATE.getMonth() + 1, DATE.getDate()),
+  });
   return (
     <>
       <Title>오늘의 경기</Title>
       <TodayMatchListContainer>
-        {DATA.map((match) => (
-          <TodayMatchItem key={match.id} match={match} />
-        ))}
+        {data?.map((match) => <TodayMatchItem key={match.id} match={match} />)}
       </TodayMatchListContainer>
     </>
   );


### PR DESCRIPTION
## 🤷‍♂️ Description
오늘의경기 리스트 API 연동
<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] 오늘의경기 리스트 API 연동

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->
<img width="350" alt="스크린샷 2024-08-13 오후 4 08 45" src="https://github.com/user-attachments/assets/fc831056-27db-4f18-892d-cea0b043605a">

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
closes #84 
