### PR TITLE
Feat/#58 내직관 - 리스트 UI

### DIFF
--- a/src/components/common/Calendar.tsx
+++ b/src/components/common/Calendar.tsx
@@ -8,47 +8,46 @@ import WinIcon from "../../assets/Icons/win.svg?react";
 import LoseIcon from "../../assets/Icons/lose.svg?react";
 import TieIcon from "../../assets/Icons/tie.svg?react";
 import NoGameIcon from "../../assets/Icons/no-game.svg?react";
+import { MyGame } from "../../types/Game";
 
 interface CalendarProps {
-  data?: any;
+  data?: MyGame[];
 }
 
 const CalendarContainer = ({ data }: CalendarProps) => {
-  const titleContent = ({ date }: any) => {
-    const match = data.find(
-      (item: any) =>
-        item.date.toLocaleDateString() === date.toLocaleDateString(),
+  function titleContent({ date }: any) {
+    const match = data?.find(
+      (item: any) => moment(date).format("YYYY-MM-DD") === item.game.date,
     );
 
     if (match) {
-      if (match.result === "win") {
+      if (match.status === "WIN") {
         return <WinIcon />;
       }
-      if (match.result === "lose") {
+      if (match.status === "Lose") {
         return <LoseIcon />;
       }
-      if (match.result === "draw") {
+      if (match.status === "Tie") {
         return <TieIcon />;
       }
     }
     return null; // 일치하는 데이터가 없을 경우 아무것도 표시하지 않음
-  };
+  }
 
   // 특정 날짜에 대한 클래스 반환
   const tileClassName = ({ date }: any) => {
-    const match = data.find(
-      (item: any) =>
-        item.date.toLocaleDateString() === date.toLocaleDateString(),
+    const match = data?.find(
+      (item: any) => moment(date).format("YYYY-MM-DD") === item.game.date,
     );
 
     if (match) {
-      if (match.result === "win") {
+      if (match.status === "WIN") {
         return "event-tile win";
       }
-      if (match.result === "lose") {
+      if (match.status === "Lose") {
         return "event-tile lose";
       }
-      if (match.result === "draw") {
+      if (match.status === "Tie") {
         return "event-tile draw";
       }
     }

--- a/src/components/watchList/GameListItem.tsx
+++ b/src/components/watchList/GameListItem.tsx
@@ -1,0 +1,75 @@
+import styled from "styled-components";
+import { MyGame } from "../../types/Game";
+import ResultLabel from "./ResultLabel";
+import Text from "../common/Text";
+
+interface GameListItemProps {
+  data: MyGame;
+}
+
+// TODO: 파일명 좀 더 구체적으로 변경하기
+// TODO: 아이콘 추가, 그 전에 아이콘 컴포넌트화
+const GameListItem = ({ data }: GameListItemProps) => {
+  return (
+    <GameListItemContainer>
+      <ResultLabel status={data.status}>{data.status}</ResultLabel>
+      <div className='game-info'>
+        <div
+          className={`team-score ${data.game.homeTeam.name === data.game.winningTeam.name ? "highlight" : ""}`}>
+          <Text variant='subtitle_02'>{data.game.homeTeam.name}</Text>
+          <Text variant='subtitle_02'>{data.game.homeTeamScore}</Text>
+        </div>
+        <div
+          className={`team-score ${data.game.awayTeam.name === data.game.winningTeam.name ? "highlight" : ""}`}>
+          <Text variant='subtitle_02'>{data.game.awayTeam.name}</Text>
+          <Text variant='subtitle_02'>{data.game.awayTeamScore}</Text>
+        </div>
+      </div>
+      <div className='vertical-line' />
+      <div className='game-info-stadium'>
+        <Text variant='caption'>2024.05.24</Text>
+        <Text variant='caption'>{data.game.stadium.name} 야구장</Text>
+      </div>
+    </GameListItemContainer>
+  );
+};
+const GameListItemContainer = styled.li`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  padding: 12px 0px;
+  gap: 8px;
+  height: 84px;
+
+  .game-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 4px 8px;
+    color: var(--gray-200);
+
+    .highlight {
+      color: var(--black);
+    }
+  }
+
+  .vertical-line {
+    width: 1px;
+    height: 100%;
+    background-color: black;
+    border: 1px solid #efefef;
+  }
+
+  .team-score {
+    display: flex;
+    justify-content: space-between;
+    min-width: 126px;
+  }
+  .game-info-stadium {
+    display: flex;
+    flex-direction: column;
+  }
+`;
+
+export default GameListItem;

--- a/src/components/watchList/ListTab.tsx
+++ b/src/components/watchList/ListTab.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import styled from "styled-components";
+import ArrowLeftIcon from "../../assets/Icons/arrow-left.svg?react";
+import ArrowRightIcon from "../../assets/Icons/arrow-right.svg?react";
+import GameListItem from "./GameListItem";
+
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+interface GameListItemProps {
+  data?: any;
+}
+
+const ListTab = ({ data }: GameListItemProps) => {
+  const [date, setDate] = useState(new Date());
+
+  return (
+    <ListContainer>
+      <nav>
+        <ArrowLeftIcon
+          onClick={() => {
+            const newDate = new Date(date);
+            newDate.setMonth(date.getMonth() - 1);
+            setDate(newDate);
+          }}
+          fill='#2F3036'
+        />
+        <span>
+          {MONTHS[date.getMonth()]} {date.getFullYear()}
+        </span>
+        <ArrowRightIcon
+          onClick={() => {
+            const newDate = new Date(date);
+            newDate.setMonth(date.getMonth() + 1);
+            setDate(newDate);
+          }}
+          fill='#2F3036'
+        />
+      </nav>
+      <GameList>
+        {data.map((item: any) => (
+          <GameListItem key={item.id} data={item} />
+        ))}
+      </GameList>
+    </ListContainer>
+  );
+};
+const ListContainer = styled.div`
+  margin-top: 20px;
+  nav {
+    display: flex;
+    justify-content: space-between;
+  }
+`;
+
+const GameList = styled.ul`
+  width: 100%;
+`;
+
+export default ListTab;

--- a/src/components/watchList/ResultLabel.tsx
+++ b/src/components/watchList/ResultLabel.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import styled from "styled-components";
+import { typography } from "../../style/typography";
+
+interface ResultLabelProps {
+  status: "WIN" | "Lose" | "Tie" | "No game";
+  children: React.ReactNode;
+}
+
+const ResultLabel = ({ status, children }: ResultLabelProps) => {
+  return (
+    <ResultLabelContainer status={status}>{children}</ResultLabelContainer>
+  );
+};
+const ResultLabelContainer = styled.span<{ status: string }>`
+  ${typography.subtitle_01}
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 4px;
+  padding: 4px 8px;
+  height: 24px;
+  width: 66px;
+  white-space: nowrap;
+
+  color: ${({ status }) =>
+    status === "Tie" || status === "No game" ? "var(--black)" : "var(--white)"};
+
+  background-color: ${({ status, theme }) => {
+    switch (status) {
+      case "WIN":
+        return theme.colors.primary;
+      case "Lose":
+        return theme.colors.secondary;
+      case "Tie":
+        return "var(--gray-200)";
+      case "No game":
+        return "var(--gray-200)";
+      default:
+    }
+  }};
+`;
+
+export default ResultLabel;

--- a/src/components/watchList/WatchList.tsx
+++ b/src/components/watchList/WatchList.tsx
@@ -5,11 +5,162 @@ import SearchIcon from "../../assets/Icons/search.svg?react";
 import SelectionBar from "../common/SelectionBar";
 import CalendarContainer from "../common/Calendar";
 import { typography } from "../../style/typography";
+import ListTab from "./ListTab";
+import { MyGame } from "../../types/Game";
 
-const DATA = [
-  { date: new Date(2024, 7, 8), result: "win" }, // 8월 8일에 승리
-  { date: new Date(2024, 7, 16), result: "lose" }, // 8월 16일에 패배
-  { date: new Date(2024, 7, 27), result: "draw" }, // 8월 27일에 무승부
+const DATA: MyGame[] = [
+  {
+    id: 1,
+    image: "http://example.com/url/to/image.jpg",
+    seat: "115블록 2열 13번",
+    review: "좋았다",
+    status: "WIN",
+    game: {
+      id: "20240801SSLG0",
+      date: "2024-08-01",
+      time: "18:30:00",
+      status: "경기 종료",
+      homeTeam: {
+        id: 7,
+        name: "LG",
+      },
+      awayTeam: {
+        id: 4,
+        name: "삼성",
+      },
+      stadium: {
+        id: 1,
+        name: "잠실",
+        latitude: 0,
+        longitude: 0,
+        address: "no address",
+      },
+      homeTeamScore: 0,
+      awayTeamScore: 7,
+      winningTeam: {
+        id: 4,
+        name: "삼성",
+      },
+    },
+    cheeringTeam: {
+      id: 4,
+      name: "삼성",
+    },
+  },
+  {
+    id: 2,
+    image: "http://example.com/url/to/image2.jpg",
+    seat: "116블록 3열 14번",
+    review: "별로였다",
+    status: "Lose",
+    game: {
+      id: "20240802SSLG0",
+      date: "2024-08-02",
+      time: "18:30:00",
+      status: "경기 종료",
+      homeTeam: {
+        id: 7,
+        name: "LG",
+      },
+      awayTeam: {
+        id: 4,
+        name: "삼성",
+      },
+      stadium: {
+        id: 1,
+        name: "잠실",
+        latitude: 0,
+        longitude: 0,
+        address: "no address",
+      },
+      homeTeamScore: 5,
+      awayTeamScore: 7,
+      winningTeam: {
+        id: 4,
+        name: "삼성",
+      },
+    },
+    cheeringTeam: {
+      id: 7,
+      name: "삼성",
+    },
+  },
+  {
+    id: 3,
+    image: "http://example.com/url/to/image3.jpg",
+    seat: "117블록 4열 15번",
+    review: "괜찮았다",
+    status: "Tie",
+    game: {
+      id: "20240803SSLG0",
+      date: "2024-08-03",
+      time: "18:30:00",
+      status: "경기 종료",
+      homeTeam: {
+        id: 7,
+        name: "LG",
+      },
+      awayTeam: {
+        id: 4,
+        name: "삼성",
+      },
+      stadium: {
+        id: 1,
+        name: "잠실",
+        latitude: 0,
+        longitude: 0,
+        address: "no address",
+      },
+      homeTeamScore: 3,
+      awayTeamScore: 3,
+      winningTeam: {
+        id: 0,
+        name: "무승부",
+      },
+    },
+    cheeringTeam: {
+      id: 4,
+      name: "삼성",
+    },
+  },
+  {
+    id: 4,
+    image: "http://example.com/url/to/image4.jpg",
+    seat: "118블록 5열 16번",
+    review: "관중 없는 경기",
+    status: "No game",
+    game: {
+      id: "20240804SSLG0",
+      date: "2024-08-04",
+      time: "18:30:00",
+      status: "경기 취소",
+      homeTeam: {
+        id: 7,
+        name: "LG",
+      },
+      awayTeam: {
+        id: 4,
+        name: "삼성",
+      },
+      stadium: {
+        id: 1,
+        name: "잠실",
+        latitude: 0,
+        longitude: 0,
+        address: "no address",
+      },
+      homeTeamScore: 0,
+      awayTeamScore: 0,
+      winningTeam: {
+        id: 0,
+        name: "경기 없음",
+      },
+    },
+    cheeringTeam: {
+      id: 7,
+      name: "삼성",
+    },
+  },
 ];
 
 const WatchList = () => {
@@ -19,7 +170,7 @@ const WatchList = () => {
       case 0:
         return <CalendarContainer data={DATA} />;
       case 1:
-        return <div>리스트</div>;
+        return <ListTab data={DATA} />;
       case 2:
         return <div>갤러리</div>;
       default:

--- a/src/types/Game.ts
+++ b/src/types/Game.ts
@@ -1,0 +1,38 @@
+export interface MyGame {
+  id: number;
+  image: string;
+  seat: string;
+  review: string;
+  status: "WIN" | "Lose" | "Tie" | "No game";
+  game: {
+    id: string;
+    date: string;
+    time: string;
+    status: string;
+    homeTeam: {
+      id: number;
+      name: string;
+    };
+    awayTeam: {
+      id: number;
+      name: string;
+    };
+    stadium: {
+      id: number;
+      name: string;
+      latitude: number;
+      longitude: number;
+      address: string;
+    };
+    homeTeamScore: number;
+    awayTeamScore: number;
+    winningTeam: {
+      id: number;
+      name: string;
+    };
+  };
+  cheeringTeam: {
+    id: number;
+    name: string;
+  };
+}


### PR DESCRIPTION
## 🤷‍♂️ Description
내 직관에서 리스트 쪽 UI 작업하였습니다.

- 리스트 내비게이션에서 달 별로 이동 시, 데이터가 바껴야하는데 아직 API 연동을 하지 않아서 뒀습니다
- svg는 공통 컴포넌트로 멘토님에 알려주신 내용으로 만들어보고 추가하겠습니다.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] 리스트 부분 UI 작업
- [x] 게임의 상태에 따라 win, lose, tie, no game 추가

## 📷 Screenshots
<img width="373" alt="스크린샷 2024-08-13 오후 7 22 42" src="https://github.com/user-attachments/assets/3d45b445-275f-49f5-b6d0-bca9d6869978">

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
