### PR TITLE
Chore/#102 공통 Text컴포넌트 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -132,6 +132,10 @@ const router = createBrowserRouter([
       {
         path: "/ranking",
         element: <Ranking />,
+      },
+    ],
+  },
+  {
     path: "/mypage/profile",
     element: (
       <Layout

--- a/src/components/common/Text.tsx
+++ b/src/components/common/Text.tsx
@@ -7,19 +7,29 @@ type TextTags = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
 interface TextProps extends Omit<React.HTMLAttributes<HTMLElement>, "as"> {
   as?: Extract<React.ElementType, TextTags>;
   variant?: keyof typeof typography;
+  color?: string;
   children: React.ReactNode;
 }
 
-const Text = ({ variant = "body_01", as = "span", children }: TextProps) => {
+const Text = ({
+  variant = "body_01",
+  as = "span",
+  color,
+  children,
+}: TextProps) => {
   return (
-    <TextComponent as={as} variant={variant}>
+    <TextComponent as={as} variant={variant} color={color}>
       {children}
     </TextComponent>
   );
 };
 
-const TextComponent = styled.span<{ variant: keyof typeof typography }>`
+const TextComponent = styled.span<{
+  variant: keyof typeof typography;
+  color?: string;
+}>`
   ${({ variant }) => typography[variant]}
+  color: ${({ color }) => color || "inherit"};
 `;
 
 export default Text;


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->
공통 Text컴포넌트에 컬러 설정
```typescript
const Text = ({
  variant = "body_01",
  as = "span",
  color,
  children,
}: TextProps) => {
  return (
    <TextComponent as={as} variant={variant} color={color}>
      {children}
    </TextComponent>
  );
};

const TextComponent = styled.span<{
  variant: keyof typeof typography;
  color?: string;
}>`
  ${({ variant }) => typography[variant]}
  color: ${({ color }) => color || "inherit"};
`;

export default Text;

```
## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] 공통 Text컴포넌트에 컬러 설정

closes #102 

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
