### PR TITLE
[Chore] Footer안쓰는 페이지 조정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,7 @@ const BackButton = () => {
 const router = createBrowserRouter([
   {
     path: "/",
-    element: <Layout />,
+    element: <Layout footer={false} />,
     children: [
       {
         path: "/",
@@ -76,7 +76,7 @@ const router = createBrowserRouter([
   },
   {
     path: "/signup",
-    element: <Layout left={<BackButton />} />,
+    element: <Layout footer={false} left={<BackButton />} />,
     children: [
       {
         path: "/signup",

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -3,14 +3,18 @@ import styled from "styled-components";
 import Header, { HeaderProps } from "../common/Header";
 import Footer from "../common/Footer";
 
-const Layout = ({ left, center, right }: HeaderProps) => {
+interface LayoutProps extends HeaderProps {
+  footer?: boolean;
+}
+
+const Layout = ({ left, center, right, footer = true }: LayoutProps) => {
   return (
     <LayoutConatiner>
       <Header left={left} center={center} right={right} />
       <MainWrapper>
         <Outlet />
       </MainWrapper>
-      <Footer />
+      {footer && <Footer />}
     </LayoutConatiner>
   );
 };

--- a/src/components/mypage/ProfileButtons.tsx
+++ b/src/components/mypage/ProfileButtons.tsx
@@ -118,7 +118,6 @@ const ProfileButtons = () => {
             회원탈퇴
           </Text>
         </div>
-
       </ProfileLogWrapper>
     </Container>
   );


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->
Footer안쓰는 페이지 조정
```typescript
interface LayoutProps extends HeaderProps {
  footer?: boolean;
}

const Layout = ({ left, center, right, footer = true }: LayoutProps) => {
  return (
    <LayoutConatiner>
      <Header left={left} center={center} right={right} />
      <MainWrapper>
        <Outlet />
      </MainWrapper>
      {footer && <Footer />}
    </LayoutConatiner>
  );
};
```
사용법
```typescript
{
    path: "/signup",
    element: <Layout footer={false} left={<BackButton />} />,
    children: [
      {
        path: "/signup",
        element: <Signup />,
      },
    ],
  },
```
## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] Footer안쓰는 페이지 조정

closes #123 
## 📷 Screenshots
![image](https://github.com/user-attachments/assets/db1e1d46-02bb-45b4-87d0-22e1b4ad74c4)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
