### PR TITLE
Feat/#138 응원 팀 경기 최상단 Default 선택 되도록하기

### DIFF
--- a/src/assets/Icons/_index.ts
+++ b/src/assets/Icons/_index.ts
@@ -36,3 +36,4 @@ export { default as IcShow } from "./show.svg?react";
 export { default as IcSwitch } from "./switch.svg?react";
 export { default as IcTie } from "./tie.svg?react";
 export { default as IcWin } from "./win.svg?react";
+export { default as IcPolygon } from "./polygon.svg?react";

--- a/src/assets/Icons/polygon.svg
+++ b/src/assets/Icons/polygon.svg
@@ -1,0 +1,3 @@
+<svg width="6" height="8" viewBox="0 0 6 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 4L6 0.535898L6 7.4641L0 4Z" fill="#2F3036"/>
+</svg>

--- a/src/components/dailyMatch/DailyMatch.tsx
+++ b/src/components/dailyMatch/DailyMatch.tsx
@@ -1,4 +1,6 @@
 import styled from "styled-components";
+import { setCheerTeamFirst } from "@/utils/setCheerTeamFirst";
+import { useEffect } from "react";
 import { Game } from "../../types/Game";
 import DailyMatchItem from "./DailyMatchItem";
 
@@ -13,9 +15,15 @@ const DailyMatch = ({
   selectedMatch,
   setSelectedMatch,
 }: DailyMatchProps) => {
+  const formatMatches = setCheerTeamFirst(matches);
+
+  useEffect(() => {
+    setSelectedMatch(formatMatches[0]);
+  }, [formatMatches, setSelectedMatch]);
+
   return (
     <DailyMatchContainer>
-      {matches.map((match) => (
+      {formatMatches.map((match) => (
         <DailyMatchItem
           key={match.id}
           match={match}

--- a/src/components/dailyMatch/DailyMatchItem.tsx
+++ b/src/components/dailyMatch/DailyMatchItem.tsx
@@ -15,17 +15,29 @@ const DailyMatchItem = ({
   isSelected,
   onSelect,
 }: DailyMatchItemProps) => {
+  const isWinningTeam = (teamId: number) => {
+    if (match.winningTeam === null) return false;
+    return match.winningTeam.id === teamId;
+  };
   return (
     <DailyMatchItemContainer isSelected={isSelected}>
       <Radio checked={isSelected} onChange={onSelect} />
       <div className='game-info'>
-        <div className='team-score'>
+        <div
+          className={`team-score ${isWinningTeam(match.homeTeam.id) ? "winning" : ""}`}>
           <Text variant='subtitle_02'>{match.homeTeam.name}</Text>
           <Text variant='subtitle_02'>{match.homeTeamScore}</Text>
+          {isWinningTeam(match.homeTeam.id) && (
+            <Icon icon='IcPolygon' width={10} height={10} />
+          )}
         </div>
-        <div className='team-score'>
+        <div
+          className={`team-score ${isWinningTeam(match.awayTeam.id) ? "winning" : ""}`}>
           <Text variant='subtitle_02'>{match.awayTeam.name}</Text>
           <Text variant='subtitle_02'>{match.awayTeamScore}</Text>
+          {isWinningTeam(match.awayTeam.id) && (
+            <Icon icon='IcPolygon' width={10} height={10} />
+          )}
         </div>
       </div>
       <div className='vertical-line' />
@@ -46,6 +58,8 @@ const DailyMatchItemContainer = styled.div<{ isSelected: boolean }>`
   gap: 16px;
   padding: 16px;
   border-radius: 8px;
+  height: 80px;
+
   border: ${({ isSelected }) =>
     isSelected ? "1px solid var(--primary-color)" : "1px solid #efefef"};
   .game-info {
@@ -54,24 +68,36 @@ const DailyMatchItemContainer = styled.div<{ isSelected: boolean }>`
     gap: 4px;
     padding: 4px 8px;
     color: var(--gray-200);
+    width: 100%;
   }
 
   .vertical-line {
-    width: 1px;
     height: 100%;
-    background-color: black;
-    border: 1px solid #efefef;
+    border: 0.1px solid #efefef;
+    margin-left: 16px;
   }
 
   .team-score {
     display: flex;
     justify-content: space-between;
     min-width: 126px;
+    position: relative;
   }
   .game-info-stadium {
     display: flex;
     flex-direction: column;
     align-items: center;
+    width: 50%;
+    white-space: nowrap;
+  }
+  .winning {
+    color: var(--primary-color);
+
+    svg {
+      position: absolute;
+      top: 20%;
+      right: -15px;
+    }
   }
 `;
 

--- a/src/utils/setCheerTeamFirst.ts
+++ b/src/utils/setCheerTeamFirst.ts
@@ -1,0 +1,19 @@
+import { useAuthStore } from "@/store/authStore";
+import { Game } from "@/types/Game";
+
+export const setCheerTeamFirst = (matches: Game[]) => {
+  const { teamId } = useAuthStore.getState();
+
+  return matches.sort((a, b) => {
+    const cheerTeamA = a.homeTeam.id === teamId || a.awayTeam.id === teamId;
+    const cheerTeamB = b.homeTeam.id === teamId || b.awayTeam.id === teamId;
+
+    if (cheerTeamA && !cheerTeamB) {
+      return -1;
+    }
+    if (!cheerTeamA && cheerTeamB) {
+      return 1;
+    }
+    return 0;
+  });
+};


### PR DESCRIPTION
## 🤷‍♂️ Description
응원 팀 경기 최상단 Default 선택 되도록하기
<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] 응원 팀 경기 최상단 Default 선택 되도록하기
- [x] 경기 목록들 배열에서, 내가 응원한 팀을 첫 번째 인덱스로 변환하는 유틸함수 추가
- [x] svg 아이콘 추가

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

https://github.com/user-attachments/assets/7c8b8cb0-ad53-4a03-9f64-f442c59b6c71

closes #138 
<!-- ex) -->
<!-- closes #1 -->
