### PR TITLE
Refactor/#250 팝업 모달 리팩토링

### DIFF
--- a/src/components/modal/Popup.tsx
+++ b/src/components/modal/Popup.tsx
@@ -1,107 +1,37 @@
 import styled from "styled-components";
-import { typography } from "@/style/typography";
 import ModalPortal from "./ModalPortal";
+import Text from "../common/Text";
 
-interface PopupProps {
-  title: string;
-  message: string;
-  closePopup: () => void;
-  type: "confirm" | "alert" | "test";
-  confirmMessage?: string;
-  confirmFunc?: () => void;
-  comp?: React.ReactNode;
-  TF?: boolean;
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+  variant: "cancel" | "confirm";
+  color?: string;
 }
 
-const Popup = ({
-  title,
-  message,
-  closePopup,
-  type,
-  confirmMessage,
-  confirmFunc,
-  comp,
-  TF,
-}: PopupProps) => {
-  const renderButtons = () => {
-    switch (type) {
-      case "confirm":
-        return (
-          <>
-            <button
-              type='button'
-              className='cancel-button'
-              onClick={closePopup}>
-              취소
-            </button>
-            <button
-              type='button'
-              className='confirm-button'
-              onClick={() => {
-                confirmFunc?.();
-                closePopup();
-              }}>
-              {confirmMessage}
-            </button>
-          </>
-        );
-      case "alert":
-        return (
-          <button
-            type='button'
-            className='confirm-button'
-            onClick={() => {
-              confirmFunc?.();
-              closePopup();
-            }}>
-            확인
-          </button>
-        );
-      case "test":
-        return (
-          <div className='test-wrapper'>
-            {comp}
-            <div className='button-wrapper'>
-              <button
-                type='button'
-                className='cancel-button'
-                onClick={closePopup}>
-                취소
-              </button>
-              <button
-                type='button'
-                className='confirm'
-                disabled={!TF}
-                onClick={() => {
-                  confirmFunc?.();
-                  closePopup();
-                }}
-                style={{
-                  backgroundColor: TF
-                    ? "var(--primary-color)"
-                    : "var(--gray-50)",
-                  color: TF ? "var(--white)" : "var(--gray-400)",
-                }}>
-                {confirmMessage}
-              </button>
-            </div>
-          </div>
-        );
-      default:
-        return null;
-    }
-  };
+export interface PopupProps {
+  title: string;
+  message: string;
+  buttons: ButtonProps[];
+}
 
+const Popup2 = ({ title, message, buttons }: PopupProps) => {
   return (
     <ModalPortal>
       <PopupWrapper>
         <PopupContainer onClick={(e) => e.stopPropagation()}>
-          <h1 className='title'>{title}</h1>
-          <p
-            className='message'
-            dangerouslySetInnerHTML={{ __html: message }}
-          />
-          <ButtonGroup>{renderButtons()}</ButtonGroup>
+          <Text variant='headline' as='h1'>
+            {title}
+          </Text>
+          <Text variant='body_long_02' as='p'>
+            {message}
+          </Text>
+          <ButtonGroup>
+            {buttons.map((button, index) => (
+              <Button key={index} {...button}>
+                <Text variant='body_02'>{button.label}</Text>
+              </Button>
+            ))}
+          </ButtonGroup>
         </PopupContainer>
       </PopupWrapper>
     </ModalPortal>
@@ -119,15 +49,6 @@ const PopupWrapper = styled.div`
   justify-content: center;
   align-items: center;
   background: rgba(0, 0, 0, 0.5);
-
-  .title {
-    ${typography.headline}
-  }
-  .message {
-    margin-top: 8px;
-    ${typography.body_long_02}
-    color: var(--primary-color);
-  }
 `;
 
 const PopupContainer = styled.div`
@@ -139,6 +60,7 @@ const PopupContainer = styled.div`
   text-align: center;
   padding: 20px;
   border-radius: 12px;
+  gap: 8px;
 `;
 
 const ButtonGroup = styled.div`
@@ -146,36 +68,26 @@ const ButtonGroup = styled.div`
   gap: 12px;
   display: flex;
   width: 100%;
-  button {
-    width: 151px;
-    height: 48px;
-    ${typography.title_02}
-    border-radius: 8px;
-    width: 100%;
-    cursor: pointer;
-  }
-  .cancel-button {
-    opacity: 0.4;
-    border: 1px solid var(--primary-color);
-  }
-  .confirm-button {
-    background: var(--primary-color);
-    color: white;
-  }
-
-  .test-wrapper {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-  }
-
-  .button-wrapper {
-    display: flex;
-    margin-top: 20px;
-    :nth-child(1) {
-      margin-right: 10px;
-    }
-  }
 `;
 
-export default Popup;
+const Button = styled.button<{ variant: "cancel" | "confirm" }>`
+  ${({ variant, color }) =>
+    variant === "cancel"
+      ? `
+    opacity: 0.4;
+    border: 1px solid var(--primary-color);
+    color: ${color || "var(--primary-color)"};
+  `
+      : `
+    background: var(--primary-color);
+    color: ${color || "white"};
+  `}
+
+  width: 151px;
+  height: 48px;
+  border-radius: 8px;
+  width: 100%;
+  cursor: pointer;
+`;
+
+export default Popup2;

--- a/src/components/mypage/ProfileButtons.tsx
+++ b/src/components/mypage/ProfileButtons.tsx
@@ -19,12 +19,27 @@ const ProfileButtons = () => {
   const closeWithDrawPopup = useCallback(() => {
     setIsOpenDraw(false);
   }, []);
-  const { Popup, isOpen, openPopup } = usePopup();
+  const { renderPopup, openPopup, closePopup } = usePopup();
   const [password, setPassword] = useState("");
   const [isPasswordValid, setIsPasswordValid] = useState<boolean>(false);
 
   const handleLogoutClick = () => {
-    openPopup();
+    openPopup({
+      title: "로그아웃",
+      message: "정말 로그아웃 하시겠습니까?",
+      buttons: [
+        {
+          label: "취소",
+          variant: "cancel",
+          onClick: closePopup,
+        },
+        {
+          label: "로그아웃",
+          variant: "confirm",
+          onClick: () => mutationLogout.mutate(),
+        },
+      ],
+    });
   };
 
   const handleWithDrawClik = () => {
@@ -94,17 +109,6 @@ const ProfileButtons = () => {
   );
   return (
     <Container>
-      {isOpen && (
-        <Popup
-          title='확인'
-          message='정말 로그아웃 하시겠습니까?'
-          type='confirm'
-          confirmMessage='로그아웃'
-          confirmFunc={() => {
-            mutationLogout.mutate();
-          }}
-        />
-      )}
       {isOpenDraw && (
         <WithDrawPopup
           title='확인'
@@ -206,6 +210,7 @@ const ProfileButtons = () => {
           </Text>
         </div>
       </ProfileLogWrapper>
+      {renderPopup()}
     </Container>
   );
 };

--- a/src/components/mypage/ProfileChange.tsx
+++ b/src/components/mypage/ProfileChange.tsx
@@ -13,7 +13,7 @@ import Icon from "../common/Icon";
 const ProfileChange = () => {
   const [image, setImage] = useState<string | null>(null);
   const [name, setName] = useState<string>("");
-  const { Popup, isOpen, openPopup } = usePopup();
+  const { renderPopup, openPopup } = usePopup();
   const { updateNickname, updateImage } = useUserStore();
   const fileInput = useRef<HTMLInputElement | null>(null);
   const onChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -73,16 +73,22 @@ const ProfileChange = () => {
     setName(e.target.value);
   };
 
+  const handleClickSave = () => {
+    openPopup({
+      title: "프로필 설정 완료",
+      message: "프로필 설정이 완료되었습니다.",
+      buttons: [
+        {
+          label: "확인",
+          variant: "confirm",
+          onClick: handleBtnClick,
+        },
+      ],
+    });
+  };
+
   return (
     <Container>
-      {isOpen && (
-        <Popup
-          title='프로필 설정 완료'
-          message='프로필 설정이 완료되었습니다.'
-          type='alert'
-          confirmFunc={handleBtnClick}
-        />
-      )}
       <Form>
         <ProfileWrapper onClick={() => fileInput.current?.click()}>
           <Avatar alt='avatar' src={image ?? "/default-avatar.png"} />
@@ -104,11 +110,12 @@ const ProfileChange = () => {
           <Icon icon='IcCancel' />
         </InputWrapper>
         <ButtonWrapper>
-          <Button type='button' onClick={openPopup}>
+          <Button type='button' onClick={handleClickSave}>
             저장
           </Button>
         </ButtonWrapper>
       </Form>
+      {renderPopup()}
     </Container>
   );
 };

--- a/src/components/mypage/TeamChange.tsx
+++ b/src/components/mypage/TeamChange.tsx
@@ -89,9 +89,10 @@ const teams: Team[] = [
 ];
 const TeamChange = () => {
   const navigate = useNavigate();
-  const { Popup, isOpen, openPopup } = usePopup();
+  const { renderPopup, openPopup } = usePopup();
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
   const { updateTeamId } = useAuthStore();
+
   const handleBtnClick = () => {
     if (selectedTeam) {
       profileChange("teamId", selectedTeam?.id);
@@ -103,16 +104,22 @@ const TeamChange = () => {
   const handleTeamSelect = (team: Team) => {
     setSelectedTeam(team);
   };
+
+  const handleClickSave = () => {
+    openPopup({
+      title: "응원팀 변경 완료",
+      message: "응원팀 변경이 완료되었습니다.",
+      buttons: [
+        {
+          label: "확인",
+          variant: "confirm",
+          onClick: handleBtnClick,
+        },
+      ],
+    });
+  };
   return (
     <Container>
-      {isOpen && (
-        <Popup
-          title='응원팀 변경 완료'
-          message='응원팀 변경이 완료되었습니다.'
-          type='alert'
-          confirmFunc={handleBtnClick}
-        />
-      )}
       <SelectedTeamBox
         color={selectedTeam?.color || "transparent"}
         bg={selectedTeam?.bg}
@@ -137,11 +144,12 @@ const TeamChange = () => {
       <ButtonWrapper>
         <Button
           type='button'
-          onClick={openPopup}
+          onClick={handleClickSave}
           disabled={selectedTeam === null}>
           <Text variant='title_02'>저장</Text>
         </Button>
       </ButtonWrapper>
+      {renderPopup()}
     </Container>
   );
 };

--- a/src/components/passwordReset/Confirmpassword.tsx
+++ b/src/components/passwordReset/Confirmpassword.tsx
@@ -3,7 +3,6 @@ import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import { changePassword } from "@/api/auth/auth.api";
 import { usePopup } from "@/hooks/usePopup";
-import { useState } from "react";
 import Button from "../common/Button";
 import InputField from "../common/InputField";
 import TitleSection from "../common/TitleSection";
@@ -22,8 +21,7 @@ const Confirmpassword = ({
   email,
   setstep,
 }: ConfirmpasswordProps) => {
-  const { Popup, openPopup, isOpen } = usePopup();
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { openPopup, renderPopup, closePopup } = usePopup();
   const navigate = useNavigate();
   const { register, watch, handleSubmit, setValue } =
     useForm<ResetpasswordFormData>({
@@ -33,10 +31,32 @@ const Confirmpassword = ({
   const onSubmit = async (data: ResetpasswordFormData) => {
     try {
       await changePassword({ email, password: data.confirmPassword });
-      openPopup();
+      openPopup({
+        title: "비밀번호 변경 성공",
+        message: "성공적으로 비밀번호 변경이 완료되었습니다!",
+        buttons: [
+          {
+            label: "확인",
+            variant: "confirm",
+            onClick: () => {
+              navigate("/login");
+              setstep(1);
+            },
+          },
+        ],
+      });
     } catch (err) {
-      setErrorMessage("비밀번호 변경 실패");
-      openPopup();
+      openPopup({
+        title: "비밀번호 변경 실패",
+        message: "비밀번호 변경에 실패했습니다. 다시 시도해 주세요.",
+        buttons: [
+          {
+            label: "확인",
+            variant: "confirm",
+            onClick: closePopup,
+          },
+        ],
+      });
     }
   };
   const passwordValue = password;
@@ -85,21 +105,7 @@ const Confirmpassword = ({
           </Button>
         </ButtonWrapper>
       </Form>
-      {isOpen && (
-        <Popup
-          title={errorMessage ? "비밀번호변경 실패" : "비밀번호변경 성공"}
-          message={
-            errorMessage
-              ? "비밀번호 변경에 실패했습니다. 다시 시도해 주세요."
-              : "성공적으로 비밀번호변경이 완료되었습니다!"
-          }
-          type='alert'
-          confirmFunc={() => {
-            navigate("/login");
-            setstep(1);
-          }}
-        />
-      )}
+      {renderPopup()}
     </Container>
   );
 };

--- a/src/components/signup/TeamSelect.tsx
+++ b/src/components/signup/TeamSelect.tsx
@@ -101,8 +101,7 @@ const TeamSelect = ({
 }: TeamSelectProps) => {
   const navigate = useNavigate();
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
-  const { Popup, openPopup, isOpen } = usePopup();
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { openPopup, renderPopup, closePopup } = usePopup();
   const handleTeamSelect = (team: Team) => {
     setSelectedTeam(team);
     handleSetUserInfo({ teamId: team.id });
@@ -118,10 +117,32 @@ const TeamSelect = ({
         password: userInfo.password,
       };
       await signUp(data);
-      openPopup();
+      openPopup({
+        title: "회원가입 성공",
+        message: "성공적으로 회원가입이 완료되었습니다!",
+        buttons: [
+          {
+            label: "확인",
+            variant: "confirm",
+            onClick: () => {
+              navigate("/");
+              setstep(1);
+            },
+          },
+        ],
+      });
     } catch (err) {
-      setErrorMessage("회원가입 실패");
-      openPopup();
+      openPopup({
+        title: "회원가입 실패",
+        message: "회원가입에 실패했습니다. 다시 시도해 주세요.",
+        buttons: [
+          {
+            label: "확인",
+            variant: "confirm",
+            onClick: closePopup,
+          },
+        ],
+      });
     }
   };
 
@@ -157,21 +178,7 @@ const TeamSelect = ({
           승리요정 시작하기
         </Button>
       </ButtonWrapper>
-      {isOpen && (
-        <Popup
-          title={errorMessage ? "회원가입 실패" : "회원가입 성공"}
-          message={
-            errorMessage
-              ? "회원가입에 실패했습니다. 다시 시도해 주세요."
-              : "성공적으로 회원가입이 완료되었습니다!"
-          }
-          type='alert'
-          confirmFunc={() => {
-            navigate("/");
-            setstep(1);
-          }}
-        />
-      )}
+      {renderPopup()}
     </Container>
   );
 };

--- a/src/hooks/usePopup.tsx
+++ b/src/hooks/usePopup.tsx
@@ -1,52 +1,31 @@
-import { useCallback, useState } from "react";
-import Popup from "../components/modal/Popup";
+import { useState, useCallback } from "react";
+import Popup, { PopupProps } from "@/components/modal/Popup";
 
+// 팝업 훅 정의
 export const usePopup = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const [popupProps, setPopupProps] = useState<PopupProps | null>(null);
 
-  const openPopup = useCallback(() => {
+  // 팝업 열기 함수
+  const openPopup = useCallback((props: PopupProps) => {
+    setPopupProps(props);
     setIsOpen(true);
   }, []);
 
+  // 팝업 닫기 함수
   const closePopup = useCallback(() => {
     setIsOpen(false);
   }, []);
 
-  const PopupComponent = useCallback(
-    ({
-      title,
-      message,
-      type,
-      confirmMessage,
-      confirmFunc,
-      comp,
-      TF = false,
-    }: {
-      title: string;
-      message: string;
-      type: "confirm" | "alert" | "test";
-      confirmMessage?: string;
-      confirmFunc?: () => void;
-      comp?: React.ReactNode;
-      TF?: boolean;
-    }) => (
-      <Popup
-        title={title}
-        message={message}
-        closePopup={closePopup}
-        type={type as "confirm" | "alert" | "test"}
-        confirmMessage={confirmMessage}
-        confirmFunc={confirmFunc}
-        comp={comp}
-        TF={TF}
-      />
-    ),
-    [closePopup],
-  );
+  // 팝업 렌더 함수
+  const renderPopup = () => {
+    if (!isOpen || !popupProps) return null;
+    return <Popup {...popupProps} />;
+  };
 
   return {
-    Popup: PopupComponent,
     openPopup,
-    isOpen,
+    closePopup,
+    renderPopup,
   };
 };


### PR DESCRIPTION
## 🤷‍♂️ Description
팝업 모달 리팩토링하였습니다. 
- type을 없애고 버튼 고유의 prop을 그대로 사용가능하게 하였습니다
- varaint로 cancel 또는 confirm 받아서, 취소와 확인의 디자인 들어가도록 했습니다

```tsx
const handleLogoutClick = () => {
    openPopup({
      title: "로그아웃",
      message: "정말 로그아웃 하시겠습니까?",
      buttons: [
        {
          label: "취소",
          variant: "cancel",
          onClick: closePopup,
        },
        {
          label: "로그아웃",
          variant: "confirm",
          onClick: () => mutationLogout.mutate(),
        },
      ],
    });
  };
```

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] usePopup.tsx 리팩토링
- [ ] popup 컴포넌트 리팩토링
- [ ] 팝업을 사용하는 모든 컴포넌트 수정

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
