### PR TITLE
Refactor/#254 직관 리스트 및 달력 리팩토링

### DIFF
--- a/src/components/common/Calendar.tsx
+++ b/src/components/common/Calendar.tsx
@@ -1,274 +1,156 @@
-import moment from "moment";
-import Calendar from "react-calendar";
 import styled from "styled-components";
-import { useState } from "react";
+import { Calendar as CalendarStyle, CalendarProps } from "react-calendar";
 import { typography } from "@/style/typography";
-import { MyGame } from "../../types/Game";
 import Icon from "./Icon";
+import moment from "moment";
 import Text from "./Text";
 
-interface CalendarProps {
-  data?: MyGame[];
-  onClick?: (
-    date: Date,
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-  ) => void;
-  onMonthChange?: (date: Date) => void; // Month 변경 핸들러 추가
-  selectMonth?: Date;
-}
-
-const CalendarContainer = ({
-  data,
-  onClick,
-  onMonthChange,
-  selectMonth,
-}: CalendarProps) => {
-  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
-
-  const handleClickDay = (
-    date: Date,
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-  ) => {
-    // 이벤트 타일인지 확인
-    const match = data?.find(
-      (item: any) => moment(date).format("YYYY-MM-DD") === item.game.date,
-    );
-
-    if (match) {
-      // 만약 이벤트 타일이면 클릭 이벤트 무시
-      event.stopPropagation();
-      event.preventDefault();
-      return;
-    }
-
-    // 이벤트 타일이 아닌 경우에만 날짜 선택 및 클릭 이벤트 처리
-    setSelectedDate(date);
-    if (onClick) {
-      onClick(date, event);
-    }
+const Calendar = ({ ...props }: CalendarProps) => {
+  const formatDay = (_: any, date: Date) => {
+    return moment(date).format("D");
   };
-
-  const handleMonthChange = (date: Date) => {
-    if (onMonthChange) {
-      console.log(date);
-      onMonthChange(date); // onMonthChange 핸들러 호출
-    }
+  const formatShortWeekday = (_: any, date: Date) => {
+    return moment(date).format("ddd");
   };
-
-  function titleContent({ date }: any) {
-    const match = data?.find(
-      (item: any) => moment(date).format("YYYY-MM-DD") === item.game.date,
-    );
-
-    if (match) {
-      if (match.status === "Win") {
-        return <Icon icon='IcWin' />;
-      }
-      if (match.status === "Lose") {
-        return <Icon icon='IcLose' />;
-      }
-      if (match.status === "Tie") {
-        return <Icon icon='IcTie' />;
-      }
-      if (match.status === "No game") {
-        return <Icon icon='IcNoGame' />;
-      }
-    }
-    return null; // 일치하는 데이터가 없을 경우 아무것도 표시하지 않음
-  }
-
-  // 특정 날짜에 대한 클래스 반환
-  const tileClassName = ({ date }: any) => {
-    const match = data?.find(
-      (item: any) => moment(date).format("YYYY-MM-DD") === item.game.date,
-    );
-
-    const isFutureDate = moment(date).isAfter(moment(), "day");
-    const isSelected = selectedDate && moment(date).isSame(selectedDate, "day");
-
-    if (match) {
-      if (match.status === "Win") {
-        return "event-tile win";
-      }
-      if (match.status === "Lose") {
-        return "event-tile lose";
-      }
-      if (match.status === "Tie") {
-        return "event-tile draw";
-      }
-      if (match.status === "No game") {
-        return "event-tile no-game";
-      }
-    }
-    return `${isFutureDate ? "future" : ""} ${isSelected ? "selected" : ""}`;
+  const formatMonth = (_: any, date: Date) => {
+    return moment(date).format("MMMM YYYY");
   };
-
   return (
-    <CalendarWrapper>
-      <CalendarStyle
+    <CalendarTabContainer>
+      <CalendarWrraper
         locale='ko-KR'
-        minDate={new Date(2024, 0, 1)} // 달력의 최소 날짜
-        maxDate={new Date()} // 달력의 최대 날짜
-        showNeighboringMonth={false} // 이월 날짜 보이기
-        // eslint-disable-next-line react/jsx-no-bind
-        tileContent={titleContent}
-        tileClassName={tileClassName}
-        formatDay={(_, date) => moment(date).format("D")}
-        formatYear={(_, date) => moment(date).format("YYYY")} // 네비게이션 눌렀을때 숫자 년도만 보이게
-        formatMonthYear={(_, date) => moment(date).format("MMMM YYYY")} // 네비게이션에서 August 2024 이렇게 보이도록 설정
-        formatShortWeekday={(_, date) => moment(date).format("ddd")} // 요일 2글자로 표시
-        nextLabel={<Icon icon='IcArrowRight' />}
-        prevLabel={<Icon icon='IcArrowLeft' />}
+        formatDay={formatDay}
+        formatShortWeekday={formatShortWeekday}
+        formatMonthYear={formatMonth}
+        maxDate={new Date()}
+        minDate={new Date(2024, 0, 1)}
+        minDetail='year'
         next2Label={null}
         prev2Label={null}
-        onClickDay={handleClickDay}
-        value={selectMonth}
-        onActiveStartDateChange={
-          ({ activeStartDate }) => handleMonthChange(activeStartDate!) // onActiveStartDateChange 이벤트로 Month 변경 감지
-        }
+        nextLabel={<Icon icon='IcArrowRight' />}
+        prevLabel={<Icon icon='IcArrowLeft' />}
+        showNeighboringMonth={false}
+        {...props}
       />
-      {data && (
-        <div className='explain'>
-          <div>
-            <Icon icon='IcWin' />
-            <Text variant='subtitle_01'>승리</Text>
-          </div>
-          <div>
-            <Icon icon='IcLose' />
-            <Text variant='subtitle_01'>패배</Text>
-          </div>
-          <div>
-            <Icon icon='IcTie' />
-            <Text variant='subtitle_01'>무승부</Text>
-          </div>
-          <div>
-            <Icon icon='IcNoGame' />
-            <Text variant='subtitle_01'>경기 없음</Text>
-          </div>
+      <ExplainBar>
+        <div>
+          <Icon icon='IcWin' className='win-icon' />
+          <Text variant='subtitle_01'>승리</Text>
         </div>
-      )}
-    </CalendarWrapper>
+        <div>
+          <Icon icon='IcLose' className='lose-icon' />
+          <Text variant='subtitle_01'>패배</Text>
+        </div>
+        <div>
+          <Icon icon='IcTie' />
+          <Text variant='subtitle_01'>무승부</Text>
+        </div>
+        <div>
+          <Icon icon='IcNoGame' />
+          <Text variant='subtitle_01'>경기 취소</Text>
+        </div>
+      </ExplainBar>
+    </CalendarTabContainer>
   );
 };
-
-const CalendarWrapper = styled.div`
+const CalendarTabContainer = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  border: 1px solid var(--gray-100);
+  padding: 12px;
   border-radius: 8px;
-
-  .win {
+  border: 1px solid var(--gray-50);
+  gap: 10px;
+  .win-icon {
     fill: ${({ theme }) => theme.colors.primary};
   }
-  .lose {
+  .lose-icon {
     fill: ${({ theme }) => theme.colors.secondary};
-  }
-
-  .explain {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    gap: 12px;
-    margin-bottom: 12px;
-
-    > div {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      padding: 4px;
-      width: fit-content;
-      gap: 8px;
-
-      svg {
-        width: 15px;
-        height: 15px;
-      }
-    }
   }
 `;
 
-const CalendarStyle = styled(Calendar)`
+const CalendarWrraper = styled(CalendarStyle)`
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  padding: 12px 12px 16px;
-  gap: 10px;
   background: var(--white);
   border-radius: 8px;
   width: 330px;
-  .future {
-    color: var(--gray-200);
-  }
+  margin: 0 auto;
 
-  .selected {
-    background: ${({ theme }) => theme.colors.primary};
-    color: var(--white);
-    border-radius: 50%;
-  }
-  // 상단 네비게이션
   .react-calendar__navigation {
     align-items: center;
-    margin: 0 auto;
     width: 100%;
     display: flex;
     justify-content: space-between;
-    ${typography.title_02}
-    padding:8px;
+    padding: 8px;
 
-    .react-calendar__navigation__label {
-      flex-grow: 0 !important; /* 기본 flex-grow: 1 을 덮어쓰기 */
-      pointer-events: none;
+    span {
+      cursor: pointer;
+      ${typography.title_02};
+    }
+
+    // 마지막 달 이동 버튼 색변경
+    :where([aria-disabled="true" i], [disabled]) {
+      svg {
+        fill: var(--gray-200);
+      }
     }
   }
 
-  // 요일 ex) Mon, Tue, Wed ..
-  .react-calendar__month-view__weekdays__weekday {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: var(--gray-400);
+  // mon, tue, wed, thu, fri, sat, sun
+  .react-calendar__month-view__weekdays {
+    text-align: center;
+    abbr {
+      ${typography.subtitle_02};
+      color: var(--gray-200);
+      text-decoration: none;
+    }
   }
 
-  abbr {
-    ${typography.subtitle_02}
-    text-decoration: none;
-  }
-
+  // 각 날짜 타일
   .react-calendar__tile {
-    position: relative;
-    display: flex;
-    justify-content: center;
-    align-items: center;
     width: 43px;
     height: 43px;
-    padding: 0;
   }
+
+  // 특정 날짜 타일 (승, 패, 무승부, 경기 없음)
   .event-tile {
     position: relative;
 
     abbr {
-      z-index: 1;
-    }
-    svg {
-      position: absolute;
+      display: none;
     }
   }
-  .img {
-    position: absolute;
-    width: 50px;
-    height: 50px;
-    top: 0;
-    pointer-events: none;
 
-    img {
-      width: 100%;
-      height: 100%;
-    }
+  // 아직 오지 않은 날짜
+  .future-date {
+    color: var(--gray-200);
   }
 `;
 
-export default CalendarContainer;
+const ExplainBar = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+  width: 328px;
+  margin: 0 auto;
+
+  > div {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    padding: 4px;
+    width: fit-content;
+    gap: 8px;
+  }
+
+  svg {
+    width: 15px;
+    height: 15px;
+  }
+`;
+export default Calendar;

--- a/src/components/common/MonthNav.tsx
+++ b/src/components/common/MonthNav.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import Icon from "./Icon";
+import Text from "./Text";
 
 const MONTHS = [
   "January",
@@ -60,9 +61,9 @@ const MonthNav = ({ onMonthChange, selectMonth }: MonthNavProps) => {
         fill={isPreviousDisabled() ? "#CCCCCC" : "#2F3036"} // Disabled color
         cursor={isPreviousDisabled() ? "not-allowed" : "pointer"}
       />
-      <span>
+      <Text variant='title_02'>
         {MONTHS[selectMonth.getMonth()]} {selectMonth.getFullYear()}
-      </span>
+      </Text>
       <Icon
         icon='IcArrowRight'
         onClick={handleNextMonth}
@@ -76,7 +77,7 @@ const MonthNav = ({ onMonthChange, selectMonth }: MonthNavProps) => {
 const MonthNavContainer = styled.nav`
   display: flex;
   justify-content: space-between;
-  margin-top: 20px;
+  align-items: center;
   height: 56px;
 `;
 

--- a/src/components/dailyMatch/DailyMatch.tsx
+++ b/src/components/dailyMatch/DailyMatch.tsx
@@ -16,19 +16,24 @@ const DailyMatch = ({
   setSelectedMatch,
 }: DailyMatchProps) => {
   const formatMatches = findCheerTeam(matches);
-
   useEffect(() => {
     setSelectedMatch(formatMatches!);
   }, [formatMatches, setSelectedMatch]);
 
   return (
     <DailyMatchContainer>
-      <DailyMatchItem
-        key={formatMatches?.id}
-        match={formatMatches!}
-        $isSelected={selectedMatch?.id === formatMatches?.id}
-        onSelect={() => setSelectedMatch(formatMatches!)}
-      />
+      {formatMatches ? (
+        <DailyMatchItem
+          key={formatMatches.id}
+          match={formatMatches}
+          $isSelected={selectedMatch?.id === formatMatches.id}
+          onSelect={() => setSelectedMatch(formatMatches)}
+        />
+      ) : (
+        <div>
+          <p>경기가 없습니다.</p>
+        </div>
+      )}
     </DailyMatchContainer>
   );
 };

--- a/src/components/dailyMatch/DailyMatchItem.tsx
+++ b/src/components/dailyMatch/DailyMatchItem.tsx
@@ -3,6 +3,7 @@ import { Game } from "../../types/Game";
 import Radio from "../common/Radio";
 import Text from "../common/Text";
 import Icon from "../common/Icon";
+import { motion } from "framer-motion";
 
 interface DailyMatchItemProps {
   match: Game;
@@ -19,8 +20,13 @@ const DailyMatchItem = ({
     if (match.winningTeam === null) return false;
     return match.winningTeam.id === teamId;
   };
+
   return (
-    <DailyMatchItemContainer $isSelected={$isSelected}>
+    <DailyMatchItemContainer
+      $isSelected={$isSelected}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 1 }}>
       <Radio checked={$isSelected} onChange={onSelect} />
       <div className='game-info'>
         <div
@@ -52,7 +58,7 @@ const DailyMatchItem = ({
   );
 };
 
-const DailyMatchItemContainer = styled.div<{ $isSelected: boolean }>`
+const DailyMatchItemContainer = styled(motion.div)<{ $isSelected: boolean }>`
   display: flex;
   align-items: center;
   gap: 16px;

--- a/src/components/todayMatch/TodayMatchItem.tsx
+++ b/src/components/todayMatch/TodayMatchItem.tsx
@@ -13,7 +13,6 @@ const TodayMatchItem = ({ match }: TodayMatchItemProps) => {
         <Text variant='subtitle_02'>{match.homeTeam.name}</Text>
         <Text variant='subtitle_02'>{match.awayTeam.name}</Text>
       </div>
-      {/* TODO:경기중 상태에서 왜 안떴지?? */}
       {match.status === "경기전" ? (
         <Text variant='subtitle_02'>{match.status}</Text>
       ) : (

--- a/src/components/todayMatch/TodayMatchList.tsx
+++ b/src/components/todayMatch/TodayMatchList.tsx
@@ -1,8 +1,8 @@
 import styled from "styled-components";
 import { setCheerTeamFirst } from "@/utils/setCheerTeamFirst";
 import TodayMatchItem from "./TodayMatchItem";
-import { typography } from "../../style/typography";
 import { useGame } from "../../hooks/useGame";
+import Text from "../common/Text";
 
 const DATE = new Date();
 
@@ -11,7 +11,9 @@ const TodayMatchList = () => {
   const formatMatches = data && setCheerTeamFirst(data);
   return (
     <>
-      <Title>오늘의 경기</Title>
+      <Text as='h1' variant='title_02'>
+        오늘의 경기
+      </Text>
       <TodayMatchListContainer>
         {formatMatches?.map((match) => (
           <TodayMatchItem key={match.id} match={match} />
@@ -20,11 +22,6 @@ const TodayMatchList = () => {
     </>
   );
 };
-
-const Title = styled.h1`
-  all: unset;
-  ${typography.title_02}
-`;
 
 const TodayMatchListContainer = styled.div`
   display: flex;

--- a/src/components/watchList/ActionIcons.tsx
+++ b/src/components/watchList/ActionIcons.tsx
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+import Icon from "../common/Icon";
+
+interface ActionIconsProps {
+  onClickSearch: () => void;
+  onClickFilter: () => void;
+}
+
+const ActionIcons = ({ onClickSearch, onClickFilter }: ActionIconsProps) => {
+  return (
+    <ActionIconsContainer>
+      <Icon icon='IcFilter' cursor='pointer' onClick={onClickFilter} />
+      <Icon icon='IcSearch' cursor='pointer' onClick={onClickSearch} />
+    </ActionIconsContainer>
+  );
+};
+const ActionIconsContainer = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+export default ActionIcons;

--- a/src/components/watchList/FilterMenu.tsx
+++ b/src/components/watchList/FilterMenu.tsx
@@ -1,0 +1,58 @@
+import styled from "styled-components";
+import { GameStatus } from "@/types/Game";
+import Text from "../common/Text";
+
+const FILTERS = [
+  { label: "전체", value: "All" },
+  { label: "이긴 경기", value: "Win" },
+  { label: "진 경기", value: "Lose" },
+  { label: "비긴 경기", value: "Tie" },
+  { label: "경기 취소", value: "No game" },
+];
+
+interface FilterMenuProps {
+  onSelectFilter: (filter: GameStatus) => void;
+}
+
+const FilterMenu = ({ onSelectFilter }: FilterMenuProps) => {
+  return (
+    <FilterMenuContainer>
+      {FILTERS.map((filter) => (
+        <FilterItem
+          key={filter.value}
+          onClick={() => onSelectFilter(filter.value as GameStatus)}>
+          <Text variant='subtitle_02'>{filter.label}</Text>
+        </FilterItem>
+      ))}
+    </FilterMenuContainer>
+  );
+};
+const FilterMenuContainer = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  gap: 8px;
+  z-index: 10;
+  position: absolute;
+  width: 120px;
+  right: 0;
+  top: 24px;
+  background: #ffffff;
+  border: 1px solid #efefef;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.05);
+  border-radius: 8px;
+`;
+const FilterItem = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 8px;
+  gap: 10px;
+  width: 96px;
+  height: 34px;
+  border-bottom: 1px solid var(--gray-50);
+  cursor: pointer;
+`;
+
+export default FilterMenu;

--- a/src/components/watchList/ListTab/ListTab.tsx
+++ b/src/components/watchList/ListTab/ListTab.tsx
@@ -24,6 +24,7 @@ const ListContainer = styled.div``;
 
 const GameList = styled.ul`
   width: 100%;
+  margin: 0;
 `;
 
 export default ListTab;

--- a/src/components/watchList/SearchBar.tsx
+++ b/src/components/watchList/SearchBar.tsx
@@ -1,0 +1,58 @@
+import styled from "styled-components";
+import Icon from "../common/Icon";
+
+interface SearchBarProps {
+  searchValue: string;
+  onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onClearSearch: () => void;
+}
+
+const SearchBar = ({
+  searchValue,
+  onSearchChange,
+  onClearSearch,
+}: SearchBarProps) => {
+  return (
+    <SearchContainer>
+      {searchValue ? (
+        <Icon icon='IcCancel' cursor='pointer' onClick={onClearSearch} />
+      ) : (
+        <Icon icon='IcSearch' cursor='pointer' fill='var(--gray-200)' />
+      )}
+      <SearchInput
+        type='text'
+        placeholder='경기장을 검색해주세요.'
+        onChange={onSearchChange}
+        value={searchValue}
+      />
+    </SearchContainer>
+  );
+};
+
+export default SearchBar;
+
+const SearchContainer = styled.div`
+  position: relative;
+  svg {
+    position: absolute;
+    z-index: 1;
+    right: 10px;
+    top: 6px;
+    width: 20px;
+    height: 20px;
+  }
+`;
+
+const SearchInput = styled.input`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  gap: 10px;
+  background: var(--gray-50);
+  border-radius: 8px;
+  border: none;
+  height: 36px;
+  width: 100%;
+`;

--- a/src/components/watchList/WatchList.tsx
+++ b/src/components/watchList/WatchList.tsx
@@ -32,14 +32,6 @@ const WatchList = () => {
     setSelectMonth(date);
   };
 
-  const handleClickDay = (date: Date) => {
-    registeredGames?.forEach((item: MyGame) => {
-      if (item.game.date === moment(date).format("YYYY-MM-DD")) {
-        navigate(`/detail/${item.id}`);
-      }
-    });
-  };
-
   const handleClickMatch = (id: number) => {
     navigate(`/detail/${id}`);
   };
@@ -92,7 +84,6 @@ const WatchList = () => {
         return (
           <CalendarTab
             onMonthChange={handleMonthChange}
-            selectMonth={selectMonth}
             registeredGames={isSuccess ? filteredRegisteredGames! : []}
           />
         );

--- a/src/components/watchList/WatchList.tsx
+++ b/src/components/watchList/WatchList.tsx
@@ -1,40 +1,39 @@
 import styled from "styled-components";
 import { useState, useMemo } from "react";
-import { typography } from "@/style/typography";
-import { MyGame } from "@/types/Game";
+import { GameStatus, MyGame } from "@/types/Game";
 import moment from "moment";
 import { useNavigate } from "react-router-dom";
 import { useRegisteredGame } from "@/hooks/useRegisteredGame";
 import ListTab from "./ListTab/ListTab";
 import SelectionBar from "../common/SelectionBar";
-import CalendarContainer from "../common/Calendar";
 import GalleryTab from "./GalleryTab/GalleryTab";
 import MonthNav from "../common/MonthNav";
-import Icon from "../common/Icon";
 import Text from "../common/Text";
+import ActionIcons from "./ActionIcons";
+import SearchBar from "./SearchBar";
+import FilterMenu from "./FilterMenu";
+import CalendarTab from "./calendarTab/CalendarTab";
 
 const WatchList = () => {
+  const navigate = useNavigate();
+
   const [activeSelect, setActiveSelect] = useState(0);
   const [selectMonth, setSelectMonth] = useState(new Date());
   const [search, setSearch] = useState({
     state: false,
     value: "",
   });
-  const [filter, setFilter] = useState(false);
-  const [selectedFilter, setSelectedFilter] = useState<
-    "All" | "Win" | "Lose" | "Tie" | "No game"
-  >("All");
+  const [isFilter, setIsFilter] = useState(false);
+  const [selectedFilter, setSelectedFilter] = useState<GameStatus>("All");
 
-  const navigate = useNavigate();
-
-  const { data, isSuccess } = useRegisteredGame(selectMonth);
+  const { registeredGames, isSuccess } = useRegisteredGame(selectMonth);
 
   const handleMonthChange = (date: Date) => {
     setSelectMonth(date);
   };
 
   const handleClickDay = (date: Date) => {
-    data?.forEach((item: MyGame) => {
+    registeredGames?.forEach((item: MyGame) => {
       if (item.game.date === moment(date).format("YYYY-MM-DD")) {
         navigate(`/detail/${item.id}`);
       }
@@ -45,15 +44,14 @@ const WatchList = () => {
     navigate(`/detail/${id}`);
   };
 
-  const handleClickSearch = () => {
+  const handleClickSearch = () =>
     setSearch({
       state: !search.state,
       value: "",
     });
-  };
 
   const handleClickFilter = () => {
-    setFilter(!filter);
+    setIsFilter(!isFilter);
   };
 
   const handleChangeSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -63,15 +61,13 @@ const WatchList = () => {
     });
   };
 
-  const handleFilterSelect = (
-    filterType: "All" | "Win" | "Lose" | "Tie" | "No game",
-  ) => {
+  const handleFilterSelect = (filterType: GameStatus) => {
     setSelectedFilter(filterType);
-    setFilter(false); // Close the filter dropdown after selection
+    setIsFilter(false);
   };
 
-  const filteredData = useMemo(() => {
-    let filtered = data;
+  const filteredRegisteredGames = useMemo(() => {
+    let filtered = registeredGames;
 
     if (search.value.trim()) {
       filtered = filtered?.filter((item: MyGame) =>
@@ -88,23 +84,22 @@ const WatchList = () => {
     }
 
     return filtered;
-  }, [data, search.value, selectedFilter]);
+  }, [registeredGames, search.value, selectedFilter]);
 
   const renderContent = () => {
     switch (activeSelect) {
       case 0:
         return (
-          <CalendarContainer
-            onClick={(date) => handleClickDay(date)}
-            data={filteredData}
+          <CalendarTab
             onMonthChange={handleMonthChange}
             selectMonth={selectMonth}
+            registeredGames={isSuccess ? filteredRegisteredGames! : []}
           />
         );
       case 1:
         return (
           <ListTab
-            matches={isSuccess ? (filteredData ?? []) : []}
+            matches={isSuccess ? filteredRegisteredGames! : []}
             onClick={(match: MyGame) => handleClickMatch(match.id)}>
             <MonthNav
               onMonthChange={handleMonthChange}
@@ -116,7 +111,7 @@ const WatchList = () => {
         return (
           <GalleryTab
             onClick={(match: MyGame) => handleClickMatch(match.id)}
-            data={filteredData}>
+            data={filteredRegisteredGames}>
             <MonthNav
               onMonthChange={handleMonthChange}
               selectMonth={selectMonth}
@@ -131,51 +126,20 @@ const WatchList = () => {
   return (
     <WatchListContainer>
       <div className='watchList-header'>
-        <h1>직관 리스트</h1>
-        <div className='icons'>
-          <Icon icon='IcFilter' cursor='pointer' onClick={handleClickFilter} />
-          <Icon icon='IcSearch' cursor='pointer' onClick={handleClickSearch} />
-        </div>
+        <Text variant='title_02'>내 직관</Text>
+        <ActionIcons
+          onClickSearch={handleClickSearch}
+          onClickFilter={handleClickFilter}
+        />
       </div>
       {search.state && (
-        <div className='search'>
-          {search.value ? (
-            <Icon
-              icon='IcCancel'
-              cursor='pointer'
-              onClick={() => setSearch({ ...search, value: "" })}
-            />
-          ) : (
-            <Icon icon='IcSearch' cursor='pointer' fill='var(--gray-200)' />
-          )}
-          <input
-            className='search-input'
-            type='text'
-            placeholder='경기장을 검색해주세요.'
-            onChange={handleChangeSearch}
-            value={search.value}
-          />
-        </div>
+        <SearchBar
+          searchValue={search.value}
+          onSearchChange={handleChangeSearch}
+          onClearSearch={() => setSearch({ ...search, value: "" })}
+        />
       )}
-      {filter && (
-        <FilterList>
-          <FilterItem onClick={() => handleFilterSelect("All")}>
-            <Text variant='subtitle_02'>전체</Text>
-          </FilterItem>
-          <FilterItem onClick={() => handleFilterSelect("Win")}>
-            <Text variant='subtitle_02'>이긴 경기</Text>
-          </FilterItem>
-          <FilterItem onClick={() => handleFilterSelect("Lose")}>
-            <Text variant='subtitle_02'>진 경기</Text>
-          </FilterItem>
-          <FilterItem onClick={() => handleFilterSelect("Tie")}>
-            <Text variant='subtitle_02'>비긴 경기</Text>
-          </FilterItem>
-          <FilterItem onClick={() => handleFilterSelect("No game")}>
-            <Text variant='subtitle_02'>경기 취소</Text>
-          </FilterItem>
-        </FilterList>
-      )}
+      {isFilter && <FilterMenu onSelectFilter={handleFilterSelect} />}
       <SelectionBar
         labels={["달력", "리스트", "갤러리"]}
         activeSelect={activeSelect}
@@ -196,67 +160,7 @@ const WatchListContainer = styled.div`
   .watchList-header {
     display: flex;
     justify-content: space-between;
-    h1 {
-      ${typography.title_02}
-    }
-    .icons {
-      display: flex;
-      gap: 10px;
-    }
   }
-  .search {
-    position: relative;
-    svg {
-      position: absolute;
-      z-index: 1;
-      right: 10px;
-      top: 6px;
-      width: 20px;
-      height: 20px;
-    }
-  }
-  .search-input {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    padding: 8px 12px;
-    gap: 10px;
-    background: var(--gray-50);
-    border-radius: 8px;
-    border: none;
-    height: 36px;
-    width: 100%;
-  }
-`;
-
-const FilterList = styled.div`
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  padding: 12px;
-  gap: 8px;
-  z-index: 10;
-  position: absolute;
-  width: 120px;
-  right: 0;
-  top: 24px;
-  background: #ffffff;
-  border: 1px solid #efefef;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.05);
-  border-radius: 8px;
-`;
-
-const FilterItem = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  padding: 8px;
-  gap: 10px;
-  width: 96px;
-  height: 34px;
-  border-bottom: 1px solid var(--gray-50);
-  cursor: pointer;
 `;
 
 export default WatchList;

--- a/src/components/watchList/calendarTab/CalendarTab.tsx
+++ b/src/components/watchList/calendarTab/CalendarTab.tsx
@@ -1,0 +1,252 @@
+import Icon from "@/components/common/Icon";
+import Text from "@/components/common/Text";
+import { typography } from "@/style/typography";
+import { MyGame } from "@/types/Game";
+import moment from "moment";
+import Calendar from "react-calendar";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+
+interface CalendarProps {
+  registeredGames: MyGame[];
+  onMonthChange: (date: Date) => void;
+  selectMonth: Date;
+}
+
+const CalendarTab = ({
+  registeredGames,
+  onMonthChange,
+  selectMonth,
+}: CalendarProps) => {
+  const navigate = useNavigate();
+
+  const formatDay = (_: any, date: Date) => {
+    return moment(date).format("D");
+  };
+  const formatShortWeekday = (_: any, date: Date) => {
+    return moment(date).format("ddd");
+  };
+  const formatMonth = (_: any, date: Date) => {
+    return moment(date).format("MMMM YYYY");
+  };
+
+  const handleClickRegisteredGame = (date: Date) => {
+    const match = registeredGames?.find(
+      (item: any) => moment(date).format("YYYY-MM-DD") === item.game.date,
+    );
+
+    if (match) {
+      navigate(`/detail/${match.id}`);
+    }
+  };
+
+  const tileContent = ({ date }: any) => {
+    const match = registeredGames?.find(
+      (item: any) => moment(date).format("YYYY-MM-DD") === item.game.date,
+    );
+    if (match && match.status === "Win") {
+      return (
+        <Icon
+          onClick={() => handleClickRegisteredGame(date)}
+          icon='IcWin'
+          className='win-icon'
+          cursor='pointer'
+        />
+      );
+    }
+    if (match && match.status === "Lose") {
+      return (
+        <Icon
+          onClick={() => handleClickRegisteredGame(date)}
+          icon='IcLose'
+          className='lose-icon'
+          cursor='pointer'
+        />
+      );
+    }
+    if (match && match.status === "Tie") {
+      return (
+        <Icon
+          onClick={() => handleClickRegisteredGame(date)}
+          icon='IcTie'
+          cursor='pointer'
+        />
+      );
+    }
+    if (match && match.status === "No game") {
+      return (
+        <Icon
+          onClick={() => handleClickRegisteredGame(date)}
+          icon='IcNoGame'
+          cursor='pointer'
+        />
+      );
+    }
+  };
+
+  const tileClassName = ({ date }: any) => {
+    const match = registeredGames?.find(
+      (item: any) => moment(date).format("YYYY-MM-DD") === item.game.date,
+    );
+    const isFutureDate = moment(date).isAfter(moment(), "day");
+
+    if (match) {
+      if (match.status === "Win") {
+        return "event-tile win";
+      }
+      if (match.status === "Lose") {
+        return "event-tile lose";
+      }
+      if (match.status === "Tie") {
+        return "event-tile draw";
+      }
+      if (match.status === "No game") {
+        return "event-tile no-game";
+      }
+    }
+    return isFutureDate ? "future-date" : "";
+  };
+
+  const handleMonthChange = (date: Date) => {
+    onMonthChange(date); // onMonthChange 핸들러 호출
+  };
+
+  return (
+    <CalendarTabContainer>
+      <CalendarStyle
+        locale='ko-KR'
+        formatDay={formatDay}
+        formatShortWeekday={formatShortWeekday}
+        formatMonthYear={formatMonth}
+        maxDate={new Date()}
+        minDate={new Date(2024, 0, 1)}
+        minDetail='year'
+        next2Label={null}
+        prev2Label={null}
+        nextLabel={<Icon icon='IcArrowRight' />}
+        prevLabel={<Icon icon='IcArrowLeft' />}
+        showNeighboringMonth={false}
+        tileContent={tileContent}
+        tileClassName={tileClassName}
+        value={selectMonth}
+        tileDisabled={({ activeStartDate, date, view }) => date.getDay() === 0}
+        onActiveStartDateChange={
+          ({ activeStartDate }) => handleMonthChange(activeStartDate!) // onActiveStartDateChange 이벤트로 Month 변경 감지
+        }
+      />
+      <ExplainBar>
+        <div>
+          <Icon icon='IcWin' className='win-icon' />
+          <Text variant='subtitle_01'>승리</Text>
+        </div>
+        <div>
+          <Icon icon='IcLose' className='lose-icon' />
+          <Text variant='subtitle_01'>패배</Text>
+        </div>
+        <div>
+          <Icon icon='IcTie' />
+          <Text variant='subtitle_01'>무승부</Text>
+        </div>
+        <div>
+          <Icon icon='IcNoGame' />
+          <Text variant='subtitle_01'>경기 취소</Text>
+        </div>
+      </ExplainBar>
+    </CalendarTabContainer>
+  );
+};
+const CalendarTabContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid var(--gray-50);
+  gap: 10px;
+  .win-icon {
+    fill: ${({ theme }) => theme.colors.primary};
+  }
+  .lose-icon {
+    fill: ${({ theme }) => theme.colors.secondary};
+  }
+`;
+
+const CalendarStyle = styled(Calendar)`
+  margin: 0 auto;
+
+  .react-calendar__navigation {
+    align-items: center;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    padding: 8px;
+
+    span {
+      cursor: pointer;
+      ${typography.title_02};
+    }
+
+    // 마지막 달 이동 버튼 색변경
+    :where([aria-disabled="true" i], [disabled]) {
+      svg {
+        fill: var(--gray-200);
+      }
+    }
+  }
+
+  // mon, tue, wed, thu, fri, sat, sun
+  .react-calendar__month-view__weekdays {
+    text-align: center;
+    abbr {
+      ${typography.subtitle_02};
+      color: var(--gray-200);
+      text-decoration: none;
+    }
+  }
+
+  // 각 날짜 타일
+  .react-calendar__tile {
+    width: 47px;
+    height: 40px;
+  }
+
+  // 특정 날짜 타일 (승, 패, 무승부, 경기 없음)
+  .event-tile {
+    position: relative;
+
+    abbr {
+      display: none;
+    }
+  }
+
+  // 아직 오지 않은 날짜
+  .future-date {
+    color: var(--gray-200);
+  }
+`;
+
+const ExplainBar = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+  width: 328px;
+  margin: 0 auto;
+
+  > div {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    padding: 4px;
+    width: fit-content;
+    gap: 8px;
+  }
+
+  svg {
+    width: 15px;
+    height: 15px;
+  }
+`;
+
+export default CalendarTab;

--- a/src/components/watchList/calendarTab/CalendarTab.tsx
+++ b/src/components/watchList/calendarTab/CalendarTab.tsx
@@ -1,34 +1,17 @@
 import Icon from "@/components/common/Icon";
-import Text from "@/components/common/Text";
-import { typography } from "@/style/typography";
 import { MyGame } from "@/types/Game";
 import moment from "moment";
-import Calendar from "react-calendar";
+import Calendar from "@/components/common/Calendar";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
 interface CalendarProps {
   registeredGames: MyGame[];
   onMonthChange: (date: Date) => void;
-  selectMonth: Date;
 }
 
-const CalendarTab = ({
-  registeredGames,
-  onMonthChange,
-  selectMonth,
-}: CalendarProps) => {
+const CalendarTab = ({ registeredGames, onMonthChange }: CalendarProps) => {
   const navigate = useNavigate();
-
-  const formatDay = (_: any, date: Date) => {
-    return moment(date).format("D");
-  };
-  const formatShortWeekday = (_: any, date: Date) => {
-    return moment(date).format("ddd");
-  };
-  const formatMonth = (_: any, date: Date) => {
-    return moment(date).format("MMMM YYYY");
-  };
 
   const handleClickRegisteredGame = (date: Date) => {
     const match = registeredGames?.find(
@@ -112,141 +95,14 @@ const CalendarTab = ({
   };
 
   return (
-    <CalendarTabContainer>
-      <CalendarStyle
-        locale='ko-KR'
-        formatDay={formatDay}
-        formatShortWeekday={formatShortWeekday}
-        formatMonthYear={formatMonth}
-        maxDate={new Date()}
-        minDate={new Date(2024, 0, 1)}
-        minDetail='year'
-        next2Label={null}
-        prev2Label={null}
-        nextLabel={<Icon icon='IcArrowRight' />}
-        prevLabel={<Icon icon='IcArrowLeft' />}
-        showNeighboringMonth={false}
-        tileContent={tileContent}
-        tileClassName={tileClassName}
-        value={selectMonth}
-        tileDisabled={({ activeStartDate, date, view }) => date.getDay() === 0}
-        onActiveStartDateChange={
-          ({ activeStartDate }) => handleMonthChange(activeStartDate!) // onActiveStartDateChange 이벤트로 Month 변경 감지
-        }
-      />
-      <ExplainBar>
-        <div>
-          <Icon icon='IcWin' className='win-icon' />
-          <Text variant='subtitle_01'>승리</Text>
-        </div>
-        <div>
-          <Icon icon='IcLose' className='lose-icon' />
-          <Text variant='subtitle_01'>패배</Text>
-        </div>
-        <div>
-          <Icon icon='IcTie' />
-          <Text variant='subtitle_01'>무승부</Text>
-        </div>
-        <div>
-          <Icon icon='IcNoGame' />
-          <Text variant='subtitle_01'>경기 취소</Text>
-        </div>
-      </ExplainBar>
-    </CalendarTabContainer>
+    <Calendar
+      tileContent={tileContent}
+      tileClassName={tileClassName}
+      onActiveStartDateChange={({ activeStartDate }) =>
+        handleMonthChange(activeStartDate!)
+      }
+    />
   );
 };
-const CalendarTabContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  padding: 12px;
-  border-radius: 8px;
-  border: 1px solid var(--gray-50);
-  gap: 10px;
-  .win-icon {
-    fill: ${({ theme }) => theme.colors.primary};
-  }
-  .lose-icon {
-    fill: ${({ theme }) => theme.colors.secondary};
-  }
-`;
-
-const CalendarStyle = styled(Calendar)`
-  margin: 0 auto;
-
-  .react-calendar__navigation {
-    align-items: center;
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-    padding: 8px;
-
-    span {
-      cursor: pointer;
-      ${typography.title_02};
-    }
-
-    // 마지막 달 이동 버튼 색변경
-    :where([aria-disabled="true" i], [disabled]) {
-      svg {
-        fill: var(--gray-200);
-      }
-    }
-  }
-
-  // mon, tue, wed, thu, fri, sat, sun
-  .react-calendar__month-view__weekdays {
-    text-align: center;
-    abbr {
-      ${typography.subtitle_02};
-      color: var(--gray-200);
-      text-decoration: none;
-    }
-  }
-
-  // 각 날짜 타일
-  .react-calendar__tile {
-    width: 47px;
-    height: 40px;
-  }
-
-  // 특정 날짜 타일 (승, 패, 무승부, 경기 없음)
-  .event-tile {
-    position: relative;
-
-    abbr {
-      display: none;
-    }
-  }
-
-  // 아직 오지 않은 날짜
-  .future-date {
-    color: var(--gray-200);
-  }
-`;
-
-const ExplainBar = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 12px;
-  width: 328px;
-  margin: 0 auto;
-
-  > div {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    padding: 4px;
-    width: fit-content;
-    gap: 8px;
-  }
-
-  svg {
-    width: 15px;
-    height: 15px;
-  }
-`;
 
 export default CalendarTab;

--- a/src/hooks/useRegisteredGame.tsx
+++ b/src/hooks/useRegisteredGame.tsx
@@ -9,10 +9,13 @@ export const useRegisteredGame = (selectMonth: Date | null) => {
     ? moment(selectMonth).format("YYYY-MM")
     : null;
 
-  const { data, isSuccess, isLoading, isError, error } = useQuery<
-    MyGame[],
-    AxiosError
-  >({
+  const {
+    data: registeredGames,
+    isSuccess,
+    isLoading,
+    isError,
+    error,
+  } = useQuery<MyGame[], AxiosError>({
     queryKey: ["registeredGame", formattedDate],
     queryFn: () =>
       selectMonth
@@ -25,5 +28,5 @@ export const useRegisteredGame = (selectMonth: Date | null) => {
     staleTime: 1000 * 60 * 3,
   });
 
-  return { data, isSuccess, isLoading, isError, error };
+  return { registeredGames, isSuccess, isLoading, isError, error };
 };

--- a/src/pages/main/Rate.tsx
+++ b/src/pages/main/Rate.tsx
@@ -30,40 +30,6 @@ const Rate = () => {
     return "0.00";
   }, [data]);
 
-  // const handleDownload = async () => {
-  //   if (!rateRef.current) {
-  //     return;
-  //   }
-  //   try {
-  //     const dataUrl = await toPng(rateRef.current, {
-  //       backgroundColor: "white",
-  //     });
-  //     const link = document.createElement("a");
-  //     link.href = dataUrl;
-  //     link.download = "승리요정.png";
-  //     document.body.appendChild(link);
-  //     link.click();
-  //     document.body.removeChild(link);
-  //   } catch (error) {
-  //     console.error("이미지 저장에 실패했습니다.", error);
-  //   }
-  // };
-  // const handleDownload = async () => {
-  //   if (!rateRef.current) {
-  //     return;
-  //   }
-  //   try {
-  //     const dataUrl = await toPng(rateRef.current, {
-  //       backgroundColor: "white",
-  //     });
-
-  //     const blob = await (await fetch(dataUrl)).blob();
-
-  //     saveAs(blob, "승리요정.png");
-  //   } catch (error) {
-  //     console.error("이미지 저장에 실패했습니다.", error);
-  //   }
-  // };
   const handleDownload = async () => {
     if (!rateRef.current) {
       return;

--- a/src/pages/register/SelectMatch.tsx
+++ b/src/pages/register/SelectMatch.tsx
@@ -4,10 +4,10 @@ import { useNavigate } from "react-router-dom";
 import { useRegisteredGame } from "@/hooks/useRegisteredGame";
 import DailyMatch from "@/components/dailyMatch/DailyMatch";
 import Loading from "@/components/common/Loading";
-import CalendarContainer from "../../components/common/Calendar";
 import { useGame } from "../../hooks/useGame";
 import Button from "../../components/common/Button";
 import { Game } from "../../types/Game";
+import SelectMatchCalendar from "./SelectMatchCalendar";
 
 const SelectMatch = () => {
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
@@ -16,21 +16,13 @@ const SelectMatch = () => {
 
   const navigate = useNavigate();
 
-  const { data: registeredGame } = useRegisteredGame(selectMonth);
+  const { registeredGames } = useRegisteredGame(selectMonth);
   const { data: matches, isSuccess, isLoading } = useGame(selectedDate);
-
-  const handleClickDay = (date: Date) => {
-    setSelectedDate(date);
-  };
 
   const handleClickButton = () => {
     if (selectedMatch) {
       navigate(`/register`, { state: { match: selectedMatch } });
     }
-  };
-
-  const handleMonthChange = (date: Date) => {
-    setSelectMonth(date);
   };
 
   const renderMatches = () => {
@@ -57,14 +49,14 @@ const SelectMatch = () => {
 
   return (
     <SelectMatchContainer>
-      <CalendarContainer
-        data={registeredGame}
-        onClick={(date) => handleClickDay(date)}
-        onMonthChange={handleMonthChange}
+      <SelectMatchCalendar
+        registeredGames={registeredGames}
+        onMonthChange={(date) => setSelectMonth(date)}
+        selectedDate={selectedDate}
+        setSelectedDate={setSelectedDate}
       />
 
       {renderMatches()}
-
       <Button
         className='button'
         onClick={handleClickButton}
@@ -75,6 +67,7 @@ const SelectMatch = () => {
     </SelectMatchContainer>
   );
 };
+
 const SelectMatchContainer = styled.div`
   height: 100%;
   padding-top: 20px;
@@ -85,6 +78,13 @@ const SelectMatchContainer = styled.div`
   }
   .loading {
     margin-top: 20px;
+  }
+  .calendar {
+    .selected {
+      background: ${({ theme }) => theme.colors.primary};
+      color: var(--white);
+      border-radius: 50%;
+    }
   }
 `;
 

--- a/src/pages/register/SelectMatchCalendar.tsx
+++ b/src/pages/register/SelectMatchCalendar.tsx
@@ -1,0 +1,90 @@
+import CalendarComponent from "@/components/common/Calendar";
+import Icon from "@/components/common/Icon";
+import moment from "moment";
+import { MyGame } from "@/types/Game";
+
+interface CalendarProps {
+  registeredGames: MyGame[] | undefined;
+  onMonthChange: (date: Date) => void;
+  selectedDate: Date | null;
+  setSelectedDate: React.Dispatch<React.SetStateAction<Date | null>>;
+}
+
+const SelectMatchCalendar = ({
+  registeredGames,
+  onMonthChange,
+  selectedDate,
+  setSelectedDate,
+}: CalendarProps) => {
+  const getRegisteredGame = (date: Date) => {
+    return registeredGames?.find(
+      (item: any) => moment(date).format("YYYY-MM-DD") === item.game.date,
+    );
+  };
+
+  const handleClickDay = (date: Date) => {
+    const match = getRegisteredGame(date);
+    if (!match) {
+      setSelectedDate(date);
+    }
+  };
+
+  const handleMonthChange = (date: Date) => {
+    onMonthChange(date);
+  };
+
+  const tileContent = ({ date }: any) => {
+    const match = getRegisteredGame(date);
+
+    if (match && match.status === "Win") {
+      return <Icon icon='IcWin' className='win-icon' />;
+    }
+    if (match && match.status === "Lose") {
+      return <Icon icon='IcLose' className='lose-icon' />;
+    }
+    if (match && match.status === "Tie") {
+      return <Icon icon='IcTie' />;
+    }
+    if (match && match.status === "No game") {
+      return <Icon icon='IcNoGame' />;
+    }
+  };
+
+  const tileClassName = ({ date }: any) => {
+    const match = registeredGames?.find(
+      (item: any) => moment(date).format("YYYY-MM-DD") === item.game.date,
+    );
+
+    const isFutureDate = moment(date).isAfter(moment(), "day");
+    const isSelected = selectedDate && moment(date).isSame(selectedDate, "day");
+
+    if (match) {
+      if (match.status === "Win") {
+        return "event-tile win";
+      }
+      if (match.status === "Lose") {
+        return "event-tile lose";
+      }
+      if (match.status === "Tie") {
+        return "event-tile draw";
+      }
+      if (match.status === "No game") {
+        return "event-tile no-game";
+      }
+    }
+    return `${isFutureDate ? "future-date" : ""} ${isSelected ? "selected" : ""}`;
+  };
+  return (
+    <CalendarComponent
+      onClickDay={handleClickDay}
+      tileContent={tileContent}
+      tileClassName={tileClassName}
+      onActiveStartDateChange={({ activeStartDate }) =>
+        handleMonthChange(activeStartDate!)
+      }
+      className='calendar'
+    />
+  );
+};
+
+export default SelectMatchCalendar;

--- a/src/types/Game.ts
+++ b/src/types/Game.ts
@@ -3,7 +3,7 @@ export interface MyGame {
   image: string;
   seat: string;
   review: string;
-  status: "Win" | "Lose" | "Tie" | "No game";
+  status: GameStatus;
   game: Game;
   cheeringTeam: Team;
 }
@@ -34,3 +34,5 @@ export interface Team {
   id: number;
   name: string;
 }
+
+export type GameStatus = "All" | "Win" | "Lose" | "Tie" | "No game";


### PR DESCRIPTION


## 🤷‍♂️ Description

공통 캘린더 컴포넌트를 추가하고 내 직관 페이지에 맞춰 컴포넌트를 리팩토링하였습니다. 이를 통해 직관 기록을 관리하는 기능을 더욱 유연하게 활용할 수 있습니다. 또한, 주석 제거 및 공통 컴포넌트로의 교체 작업을 수행하였습니다.

## 📝 Primary Commits

- 🔧 **Game 타입 설정:** `game` 관련 타입을 설정하여 코드에서 타입 안정성을 확보.
- ♻️ **내 직관 페이지 컴포넌트 분리:** 내 직관 페이지에서 사용되는 컴포넌트를 별도로 분리하여 유지보수성을 높임.
- ♻️ **내 직관쪽 달력 컴포넌트 추가:** 직관 기록을 관리할 수 있는 달력 컴포넌트를 내 직관 페이지에 추가.
- 🔧 **주석 제거 및 공통 컴포넌트로 교체:** 불필요한 주석을 제거하고, 기존 컴포넌트를 공통 컴포넌트로 변경.
- ♻️ **공통 캘린더 리팩토링:** 공통 캘린더를 유연하게 수정하여 다양한 페이지에서 활용 가능하도록 개선.

## 구현 세부사항

- [x] 공통 캘린더 컴포넌트 추가 및 리팩토링
- [x] 내 직관 페이지 컴포넌트 분리 및 달력 컴포넌트 적용
- [x] 불필요한 주석 제거 및 공통 컴포넌트 적용

## 📷 Screenshots

<!-- 스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요! -->

closes #254 