### PR TITLE
Chore/#266 직관 기록에서 모든 경기 선택 가능하게 수정 및 경기item 수정

### DIFF
--- a/src/components/common/GameListItem.tsx
+++ b/src/components/common/GameListItem.tsx
@@ -3,9 +3,10 @@ import Text from "./Text";
 import ResultLabel from "./ResultLabel";
 import Icon from "./Icon";
 import { Game, Team } from "@/types/Game";
+import { HTMLAttributes } from "react";
 
 interface GameListItemProps
-  extends Omit<React.HTMLAttributes<HTMLLIElement>, "onClick"> {
+  extends Omit<HTMLAttributes<HTMLUListElement>, "onClick"> {
   result: string | null;
   isWinningTeam: Team;
   homeTeam: Team;
@@ -15,6 +16,7 @@ interface GameListItemProps
   date: string;
   stadium: Pick<Game, "stadium">["stadium"];
   status: Pick<Game, "status">["status"];
+  onClick?: () => void;
 }
 
 const GameListItem = ({
@@ -27,6 +29,7 @@ const GameListItem = ({
   date,
   stadium,
   status,
+  onClick,
 }: GameListItemProps) => {
   // 경기 중 일때 ???
   // 응원팀 선택 전 일때 ???
@@ -40,7 +43,10 @@ const GameListItem = ({
   };
 
   return (
-    <GameListItemContainer>
+    <GameListItemContainer
+      onClick={() => {
+        if (onClick) onClick();
+      }}>
       <ResultLabel status={status} result={result} />
       <div className='game-info'>
         <div

--- a/src/components/common/GameListItem.tsx
+++ b/src/components/common/GameListItem.tsx
@@ -1,9 +1,9 @@
 import styled from "styled-components";
+import { Game, Team } from "@/types/Game";
+import { HTMLAttributes } from "react";
 import Text from "./Text";
 import ResultLabel from "./ResultLabel";
 import Icon from "./Icon";
-import { Game, Team } from "@/types/Game";
-import { HTMLAttributes } from "react";
 
 interface GameListItemProps
   extends Omit<HTMLAttributes<HTMLUListElement>, "onClick"> {
@@ -36,7 +36,7 @@ const GameListItem = ({
 
   const isWinnigTeam = (teamId: number) => {
     if (!isWinningTeam) return false;
-    if (isWinningTeam.id == teamId) {
+    if (isWinningTeam.id === teamId) {
       return true;
     }
     return false;

--- a/src/components/common/GameListItem.tsx
+++ b/src/components/common/GameListItem.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { MyGame } from "@/types/Game";
 import Text from "./Text";
-import ResultLabel from "../watchList/ListTab/ResultLabel";
+import ResultLabel from "./ResultLabel";
 import Icon from "./Icon";
 
 interface GameListItemProps

--- a/src/components/common/GameListItem.tsx
+++ b/src/components/common/GameListItem.tsx
@@ -1,54 +1,75 @@
 import styled from "styled-components";
-import { MyGame } from "@/types/Game";
 import Text from "./Text";
 import ResultLabel from "./ResultLabel";
 import Icon from "./Icon";
+import { Game, Team } from "@/types/Game";
 
 interface GameListItemProps
   extends Omit<React.HTMLAttributes<HTMLLIElement>, "onClick"> {
-  match: MyGame;
-  onClick?: (match: MyGame) => void;
+  result: string | null;
+  isWinningTeam: Team;
+  homeTeam: Team;
+  homeTeamScore: number;
+  awayTeam: Team;
+  awayTeamScore: number;
+  date: string;
+  stadium: Pick<Game, "stadium">["stadium"];
+  status: Pick<Game, "status">["status"];
 }
-// TODO : registerForm에서 재사용 할 수 있도록 리팩토링
-// 문제는 내 직관 탭에서의 데이터와 registerForm에서의 데이터가 다르다는 것
-// resultlabel을 데이터에 따라 다르게 렌더링 시켜야한다
-const GameListItem = ({ match, onClick }: GameListItemProps) => {
-  const isWinningTeam = (teamId: number) => {
-    if (match.game.winningTeam === null) return false;
-    return match.game.winningTeam.id === teamId;
-  };
 
-  const handleClick = () => {
-    onClick?.(match);
+const GameListItem = ({
+  result,
+  isWinningTeam,
+  homeTeam,
+  homeTeamScore,
+  awayTeam,
+  awayTeamScore,
+  date,
+  stadium,
+  status,
+}: GameListItemProps) => {
+  // 경기 중 일때 ???
+  // 응원팀 선택 전 일때 ???
+
+  const isWinnigTeam = (teamId: number) => {
+    if (!isWinningTeam) return false;
+    if (isWinningTeam.id == teamId) {
+      return true;
+    }
+    return false;
   };
 
   return (
-    <GameListItemContainer onClick={handleClick}>
-      <ResultLabel status={match.status}>{match.status}</ResultLabel>
+    <GameListItemContainer>
+      <ResultLabel status={status} result={result} />
       <div className='game-info'>
         <div
-          className={`team-score ${isWinningTeam(match.game.homeTeam.id) ? "winning" : ""}`}>
-          <Text variant='subtitle_02'>{match.game.homeTeam.name}</Text>
-          <Text variant='subtitle_02'>{match.game.homeTeamScore}</Text>
-          {isWinningTeam(match.game.homeTeam.id) && (
+          className={`team-score ${
+            isWinnigTeam(homeTeam.id) ? "winning" : ""
+          }`}>
+          <Text variant='subtitle_02'>{homeTeam.name}</Text>
+          <Text variant='subtitle_02'>{homeTeamScore}</Text>
+          {isWinnigTeam(homeTeam.id) && (
             <Icon icon='IcPolygon' width={10} height={10} />
           )}
         </div>
         <div
-          className={`team-score ${isWinningTeam(match.game.awayTeam.id) ? "winning" : ""}`}>
-          <Text variant='subtitle_02'>{match.game.awayTeam.name}</Text>
-          <Text variant='subtitle_02'>{match.game.awayTeamScore}</Text>
-          {isWinningTeam(match.game.awayTeam.id) && (
+          className={`team-score ${
+            isWinnigTeam(awayTeam.id) ? "winning" : ""
+          }`}>
+          <Text variant='subtitle_02'>{awayTeam.name}</Text>
+          <Text variant='subtitle_02'>{awayTeamScore}</Text>
+          {isWinnigTeam(awayTeam.id) && (
             <Icon icon='IcPolygon' width={10} height={10} />
           )}
         </div>
       </div>
       <div className='vertical-line' />
       <div className='game-info-stadium'>
-        <Text variant='caption'>{match.game.date}</Text>
+        <Text variant='caption'>{date}</Text>
         <Text variant='caption'>
           <Icon icon='IcLocation' width={15} height={15} />
-          {match.game.stadium.name} 야구장
+          {stadium.name} 야구장
         </Text>
       </div>
     </GameListItemContainer>

--- a/src/components/common/ResultLabel.tsx
+++ b/src/components/common/ResultLabel.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { MyGame } from "@/types/Game";
-import { typography } from "../../../style/typography";
+import { typography } from "../../style/typography";
 
 interface ResultLabelProps {
   status: Pick<MyGame, "status">["status"];

--- a/src/components/common/ResultLabel.tsx
+++ b/src/components/common/ResultLabel.tsx
@@ -1,20 +1,27 @@
-import React from "react";
 import styled from "styled-components";
-import { MyGame } from "@/types/Game";
-import { typography } from "../../style/typography";
+import { Game } from "@/types/Game";
+import Text from "./Text";
 
 interface ResultLabelProps {
-  status: Pick<MyGame, "status">["status"];
-  children: React.ReactNode;
+  result: string | null;
+  status: Pick<Game, "status">["status"];
 }
 
-const ResultLabel = ({ status, children }: ResultLabelProps) => {
-  return (
-    <ResultLabelContainer status={status}>{children}</ResultLabelContainer>
+const ResultLabel = ({ result, status }: ResultLabelProps) => {
+  return status === "경기전" || status === "경기중" || result === null ? (
+    <DefaultLabel>
+      <Text variant='subtitle_01'>???</Text>
+    </DefaultLabel>
+  ) : (
+    <ResultLabelContainer result={result} status={status}>
+      <Text variant='body_01'>{result}</Text>
+    </ResultLabelContainer>
   );
 };
-const ResultLabelContainer = styled.span<{ status: string }>`
-  ${typography.subtitle_01}
+const ResultLabelContainer = styled.span<{
+  result: string | null;
+  status: string;
+}>`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -24,11 +31,11 @@ const ResultLabelContainer = styled.span<{ status: string }>`
   min-width: 66px;
   white-space: nowrap;
 
-  color: ${({ status }) =>
-    status === "Tie" || status === "No game" ? "var(--black)" : "var(--white)"};
+  color: ${({ result }) =>
+    result === "Tie" || result === "No game" ? "var(--black)" : "var(--white)"};
 
-  background-color: ${({ status, theme }) => {
-    switch (status) {
+  background-color: ${({ result, theme }) => {
+    switch (result) {
       case "Win":
         return theme.colors.primary;
       case "Lose":
@@ -40,6 +47,20 @@ const ResultLabelContainer = styled.span<{ status: string }>`
       default:
     }
   }};
+`;
+
+const DefaultLabel = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 4px;
+  padding: 4px 8px;
+  height: 24px;
+  min-width: 66px;
+  white-space: nowrap;
+  box-sizing: border-box;
+  border: 1px dashed #2f3036;
+  border-radius: 4px;
 `;
 
 export default ResultLabel;

--- a/src/components/dailyMatch/DailyMatch.tsx
+++ b/src/components/dailyMatch/DailyMatch.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { useEffect } from "react";
-import { findCheerTeam } from "@/utils/findCheerTeam";
+import { setCheerTeamFirst } from "@/utils/setCheerTeamFirst";
 import { Game } from "../../types/Game";
 import DailyMatchItem from "./DailyMatchItem";
 
@@ -15,25 +15,23 @@ const DailyMatch = ({
   selectedMatch,
   setSelectedMatch,
 }: DailyMatchProps) => {
-  const formatMatches = findCheerTeam(matches);
+  const formatMatches = setCheerTeamFirst(matches);
+
   useEffect(() => {
-    setSelectedMatch(formatMatches!);
-  }, [formatMatches, setSelectedMatch]);
+    setSelectedMatch(formatMatches[0]);
+  }, [matches, setSelectedMatch]);
 
   return (
     <DailyMatchContainer>
-      {formatMatches ? (
-        <DailyMatchItem
-          key={formatMatches.id}
-          match={formatMatches}
-          $isSelected={selectedMatch?.id === formatMatches.id}
-          onSelect={() => setSelectedMatch(formatMatches)}
-        />
-      ) : (
-        <div>
-          <p>경기가 없습니다.</p>
-        </div>
-      )}
+      {formatMatches &&
+        formatMatches.map((match) => (
+          <DailyMatchItem
+            key={match.id}
+            match={match}
+            $isSelected={selectedMatch?.id === match.id}
+            onSelect={() => setSelectedMatch(match)}
+          />
+        ))}
     </DailyMatchContainer>
   );
 };

--- a/src/components/dailyMatch/DailyMatchItem.tsx
+++ b/src/components/dailyMatch/DailyMatchItem.tsx
@@ -1,9 +1,9 @@
 import styled from "styled-components";
+import { motion } from "framer-motion";
 import { Game } from "../../types/Game";
 import Radio from "../common/Radio";
 import Text from "../common/Text";
 import Icon from "../common/Icon";
-import { motion } from "framer-motion";
 
 interface DailyMatchItemProps {
   match: Game;

--- a/src/components/register/CheerTeamSelect.tsx
+++ b/src/components/register/CheerTeamSelect.tsx
@@ -3,21 +3,29 @@ import { useState, useEffect, useRef } from "react";
 import { Team } from "@/types/Game";
 import Icon from "../common/Icon";
 import Text from "../common/Text";
+import { UseFormSetValue, UseFormWatch } from "react-hook-form";
 
 interface CheerTeamSelectProps {
   setCheeringTeamId: (id: number) => void;
   awayTeam: Team;
   homeTeam: Team;
+  name: string;
+  watch: UseFormWatch<any>;
+  setValue: UseFormSetValue<any>;
 }
 
 const CheerTeamSelect = ({
   setCheeringTeamId,
   awayTeam,
   homeTeam,
+  name,
+  setValue,
+  watch,
 }: CheerTeamSelectProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [cheeringTeam, setCheeringTeam] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const cheeringTeamId = watch(name);
 
   const handleClickSelect = () => {
     setIsOpen(!isOpen);
@@ -42,9 +50,16 @@ const CheerTeamSelect = ({
 
   const handleSelectItem = (team: Team) => {
     setCheeringTeamId(team.id);
-    setCheeringTeam(team.name);
+    setValue(name, team.id);
     setIsOpen(false);
   };
+
+  const selectedTeam =
+    cheeringTeamId === homeTeam.id
+      ? homeTeam.name
+      : cheeringTeamId === awayTeam.id
+        ? awayTeam.name
+        : null;
 
   return (
     <CheerTeamSelectContainer ref={dropdownRef}>
@@ -56,10 +71,10 @@ const CheerTeamSelect = ({
         onClick={handleClickSelect}
         className='select'
         tabIndex={0}>
-        {cheeringTeam === null ? (
+        {selectedTeam === null ? (
           <Text variant='subtitle_02'>응원팀을 선택해주세요</Text>
         ) : (
-          <Text variant='subtitle_02'>{cheeringTeam}</Text>
+          <Text variant='subtitle_02'>{selectedTeam}</Text>
         )}
         <Icon icon='IcArrowDown' />
       </div>

--- a/src/components/register/CheerTeamSelect.tsx
+++ b/src/components/register/CheerTeamSelect.tsx
@@ -1,26 +1,26 @@
 import styled from "styled-components";
 import { useState, useEffect, useRef } from "react";
 import { Team } from "@/types/Game";
+import { UseFormSetValue, UseFormWatch } from "react-hook-form";
 import Icon from "../common/Icon";
 import Text from "../common/Text";
-import { UseFormSetValue, UseFormWatch } from "react-hook-form";
 
 interface CheerTeamSelectProps {
-  setCheeringTeamId: (id: number) => void;
   awayTeam: Team;
   homeTeam: Team;
   name: string;
   watch: UseFormWatch<any>;
   setValue: UseFormSetValue<any>;
+  defaultValue?: number;
 }
 
 const CheerTeamSelect = ({
-  setCheeringTeamId,
   awayTeam,
   homeTeam,
   name,
   setValue,
   watch,
+  defaultValue,
 }: CheerTeamSelectProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -30,7 +30,11 @@ const CheerTeamSelect = ({
   const handleClickSelect = () => {
     setIsOpen(!isOpen);
   };
-
+  useEffect(() => {
+    if (defaultValue) {
+      setValue(name, defaultValue);
+    }
+  }, [defaultValue, name, setValue]);
   // 드롭다운 바깥쪽을 클릭하면 드롭다운을 닫음
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -49,7 +53,6 @@ const CheerTeamSelect = ({
   }, []);
 
   const handleSelectItem = (team: Team) => {
-    setCheeringTeamId(team.id);
     setValue(name, team.id);
     setIsOpen(false);
   };

--- a/src/components/register/RegisterFormFields.tsx
+++ b/src/components/register/RegisterFormFields.tsx
@@ -1,0 +1,140 @@
+import TextAreaField from "@/components/common/TextAreaField";
+import InputField from "@/components/common/InputField";
+import Button from "@/components/common/Button";
+import { useRef, useState } from "react";
+import { useAuthStore } from "@/store/authStore";
+import { getTeamName } from "@/utils/getTeamName";
+import styled from "styled-components";
+import Icon from "@/components/common/Icon";
+import Text from "@/components/common/Text";
+
+interface RegisterFormFieldsProps {
+  onSubmit: (data: any) => void;
+  watch: any;
+  register: any;
+  setValue: any;
+}
+
+const RegisterFormFields = ({
+  onSubmit,
+  watch,
+  register,
+  setValue,
+}: RegisterFormFieldsProps) => {
+  const inputImgRef = useRef<HTMLInputElement>(null);
+  const [previewImage, setPreviewImage] = useState<string | null>(null);
+  const { ref, ...rest } = register("img");
+
+  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = event.target;
+    if (files && files.length > 0) {
+      const file = files[0];
+      const imageUrl = URL.createObjectURL(file);
+      setPreviewImage(imageUrl);
+      setValue("img", file);
+    }
+  };
+
+  const handleClickImageUpload = () => {
+    inputImgRef.current?.click();
+  };
+
+  return (
+    <Form onSubmit={onSubmit}>
+      <input
+        className='img-input'
+        type='file'
+        accept='image/jpg, image/jpeg, image/png'
+        {...rest}
+        ref={inputImgRef}
+        onChange={handleImageChange}
+      />
+
+      <ImgUploadContainer
+        hasImage={!!previewImage}
+        onClick={handleClickImageUpload}>
+        {previewImage ? (
+          <PreviewImage src={previewImage} alt='직관 사진' />
+        ) : (
+          <ImgWrraper>
+            <Icon icon='IcCamera' width={24} height={24} />
+            <Text variant='caption'>직관 사진을 업로드해주세요</Text>
+          </ImgWrraper>
+        )}
+      </ImgUploadContainer>
+      <InputField
+        label='응원팀'
+        setValue={setValue}
+        register={register}
+        watch={watch}
+        name='cheerTeam'
+        type='input'
+        disabled
+        value={getTeamName(useAuthStore().teamId)}
+      />
+      <InputField
+        label='좌석'
+        placeholder='123존 12열 1번'
+        setValue={setValue}
+        register={register}
+        watch={watch}
+        name='seat'
+        type='input'
+      />
+      <TextAreaField
+        label='메모'
+        placeholder='직관 한 마디!'
+        setValue={setValue}
+        register={register}
+        watch={watch}
+        name='review'
+      />
+      <Button size='big'>직관 기록 하기</Button>
+    </Form>
+  );
+};
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  padding: 32px 20px;
+  gap: 20px;
+
+  .img-input {
+    display: none;
+  }
+`;
+
+const ImgUploadContainer = styled.label<{ hasImage: boolean }>`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border: ${({ hasImage }) =>
+    hasImage ? "none" : "1px dashed var(--gray-200)"};
+  border-radius: 12px;
+  height: 180px;
+  width: 100%;
+  cursor: pointer;
+`;
+
+const ImgWrraper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: var(--gray-200);
+  gap: 10px;
+
+  svg {
+    fill: var(--gray-200);
+  }
+`;
+
+const PreviewImage = styled.img`
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
+  object-fit: cover;
+`;
+
+export default RegisterFormFields;

--- a/src/components/register/RegisterFormFields.tsx
+++ b/src/components/register/RegisterFormFields.tsx
@@ -2,17 +2,20 @@ import TextAreaField from "@/components/common/TextAreaField";
 import InputField from "@/components/common/InputField";
 import Button from "@/components/common/Button";
 import { useRef, useState } from "react";
-import { useAuthStore } from "@/store/authStore";
-import { getTeamName } from "@/utils/getTeamName";
 import styled from "styled-components";
 import Icon from "@/components/common/Icon";
 import Text from "@/components/common/Text";
+import CheerTeamSelect from "./CheerTeamSelect";
+import { Team } from "@/types/Team";
 
 interface RegisterFormFieldsProps {
   onSubmit: (data: any) => void;
   watch: any;
   register: any;
   setValue: any;
+  homeTeam: Team;
+  awayTeam: Team;
+  setCheeringTeamId: React.Dispatch<React.SetStateAction<number | null>>;
 }
 
 const RegisterFormFields = ({
@@ -20,6 +23,9 @@ const RegisterFormFields = ({
   watch,
   register,
   setValue,
+  homeTeam,
+  awayTeam,
+  setCheeringTeamId,
 }: RegisterFormFieldsProps) => {
   const inputImgRef = useRef<HTMLInputElement>(null);
   const [previewImage, setPreviewImage] = useState<string | null>(null);
@@ -62,15 +68,13 @@ const RegisterFormFields = ({
           </ImgWrraper>
         )}
       </ImgUploadContainer>
-      <InputField
-        label='응원팀'
+      <CheerTeamSelect
+        setCheeringTeamId={setCheeringTeamId}
+        homeTeam={homeTeam}
+        awayTeam={awayTeam}
         setValue={setValue}
-        register={register}
         watch={watch}
-        name='cheerTeam'
-        type='input'
-        disabled
-        value={getTeamName(useAuthStore().teamId)}
+        name='cheeringTeamId'
       />
       <InputField
         label='좌석'
@@ -89,7 +93,9 @@ const RegisterFormFields = ({
         watch={watch}
         name='review'
       />
-      <Button size='big'>직관 기록 하기</Button>
+      <Button size='big' type='submit' disabled={!watch("cheeringTeamId")}>
+        직관 기록 하기
+      </Button>
     </Form>
   );
 };

--- a/src/components/register/RegisterFormFields.tsx
+++ b/src/components/register/RegisterFormFields.tsx
@@ -5,8 +5,8 @@ import { useRef, useState } from "react";
 import styled from "styled-components";
 import Icon from "@/components/common/Icon";
 import Text from "@/components/common/Text";
-import CheerTeamSelect from "./CheerTeamSelect";
 import { Team } from "@/types/Team";
+import CheerTeamSelect from "./CheerTeamSelect";
 
 interface RegisterFormFieldsProps {
   onSubmit: (data: any) => void;
@@ -15,7 +15,6 @@ interface RegisterFormFieldsProps {
   setValue: any;
   homeTeam: Team;
   awayTeam: Team;
-  setCheeringTeamId: React.Dispatch<React.SetStateAction<number | null>>;
 }
 
 const RegisterFormFields = ({
@@ -25,7 +24,6 @@ const RegisterFormFields = ({
   setValue,
   homeTeam,
   awayTeam,
-  setCheeringTeamId,
 }: RegisterFormFieldsProps) => {
   const inputImgRef = useRef<HTMLInputElement>(null);
   const [previewImage, setPreviewImage] = useState<string | null>(null);
@@ -57,7 +55,7 @@ const RegisterFormFields = ({
       />
 
       <ImgUploadContainer
-        hasImage={!!previewImage}
+        $hasImage={!!previewImage}
         onClick={handleClickImageUpload}>
         {previewImage ? (
           <PreviewImage src={previewImage} alt='직관 사진' />
@@ -69,7 +67,6 @@ const RegisterFormFields = ({
         )}
       </ImgUploadContainer>
       <CheerTeamSelect
-        setCheeringTeamId={setCheeringTeamId}
         homeTeam={homeTeam}
         awayTeam={awayTeam}
         setValue={setValue}
@@ -111,13 +108,13 @@ const Form = styled.form`
   }
 `;
 
-const ImgUploadContainer = styled.label<{ hasImage: boolean }>`
+const ImgUploadContainer = styled.label<{ $hasImage: boolean }>`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  border: ${({ hasImage }) =>
-    hasImage ? "none" : "1px dashed var(--gray-200)"};
+  border: ${({ $hasImage }) =>
+    $hasImage ? "none" : "1px dashed var(--gray-200)"};
   border-radius: 12px;
   height: 180px;
   width: 100%;

--- a/src/components/watchList/ListTab/ListTab.tsx
+++ b/src/components/watchList/ListTab/ListTab.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { MyGame } from "@/types/Game";
-import GameListItem from "../../common/GameListItem";
 import { HTMLAttributes } from "react";
+import GameListItem from "../../common/GameListItem";
 
 interface GameListItemProps
   extends Omit<HTMLAttributes<HTMLUListElement>, "onClick"> {
@@ -17,6 +17,7 @@ const ListTab = ({ matches, onClick, children }: GameListItemProps) => {
       <GameList>
         {matches.map((match) => (
           <GameListItem
+            key={match.id}
             onClick={() => onClick(match.id)}
             result={match.status}
             isWinningTeam={match.game.winningTeam}

--- a/src/components/watchList/ListTab/ListTab.tsx
+++ b/src/components/watchList/ListTab/ListTab.tsx
@@ -1,11 +1,13 @@
 import styled from "styled-components";
 import { MyGame } from "@/types/Game";
 import GameListItem from "../../common/GameListItem";
+import { HTMLAttributes } from "react";
 
-interface GameListItemProps {
+interface GameListItemProps
+  extends Omit<HTMLAttributes<HTMLUListElement>, "onClick"> {
   matches: MyGame[];
-  onClick: (match: MyGame) => void;
   children: React.ReactNode;
+  onClick: (id: number) => void;
 }
 
 const ListTab = ({ matches, onClick, children }: GameListItemProps) => {
@@ -14,7 +16,18 @@ const ListTab = ({ matches, onClick, children }: GameListItemProps) => {
       {children}
       <GameList>
         {matches.map((match) => (
-          <GameListItem onClick={onClick} key={match.id} match={match} />
+          <GameListItem
+            onClick={() => onClick(match.id)}
+            result={match.status}
+            isWinningTeam={match.game.winningTeam}
+            homeTeam={match.game.homeTeam}
+            homeTeamScore={match.game.homeTeamScore}
+            awayTeam={match.game.awayTeam}
+            awayTeamScore={match.game.awayTeamScore}
+            date={match.game.date}
+            stadium={match.game.stadium}
+            status={match.game.status}
+          />
         ))}
       </GameList>
     </ListContainer>

--- a/src/components/watchList/WatchList.tsx
+++ b/src/components/watchList/WatchList.tsx
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 import { useState, useMemo } from "react";
 import { GameStatus, MyGame } from "@/types/Game";
-import moment from "moment";
 import { useNavigate } from "react-router-dom";
 import { useRegisteredGame } from "@/hooks/useRegisteredGame";
 import ListTab from "./ListTab/ListTab";

--- a/src/components/watchList/WatchList.tsx
+++ b/src/components/watchList/WatchList.tsx
@@ -31,8 +31,8 @@ const WatchList = () => {
     setSelectMonth(date);
   };
 
-  const handleClickMatch = (id: number) => {
-    navigate(`/detail/${id}`);
+  const handleClickMatch = (matchId: number) => {
+    navigate(`/detail/${matchId}`);
   };
 
   const handleClickSearch = () =>
@@ -90,7 +90,7 @@ const WatchList = () => {
         return (
           <ListTab
             matches={isSuccess ? filteredRegisteredGames! : []}
-            onClick={(match: MyGame) => handleClickMatch(match.id)}>
+            onClick={(matchId) => handleClickMatch(matchId)}>
             <MonthNav
               onMonthChange={handleMonthChange}
               selectMonth={selectMonth}

--- a/src/components/watchList/calendarTab/CalendarTab.tsx
+++ b/src/components/watchList/calendarTab/CalendarTab.tsx
@@ -3,7 +3,6 @@ import { MyGame } from "@/types/Game";
 import moment from "moment";
 import Calendar from "@/components/common/Calendar";
 import { useNavigate } from "react-router-dom";
-import styled from "styled-components";
 
 interface CalendarProps {
   registeredGames: MyGame[];

--- a/src/pages/detail/Detail.tsx
+++ b/src/pages/detail/Detail.tsx
@@ -133,19 +133,19 @@ const Detail = () => {
   if (!registeredGame) return null;
 
   const getResult = () => {
+    // 서버 API 수정 후, registeredGame.status로 변경
     if (watch("cheeringTeamId") === undefined) return null;
     if (registeredGame.game.winningTeam) {
       return registeredGame.game.winningTeam.id === watch("cheeringTeamId")
         ? "Win"
         : "Lose";
     }
-    if (
-      !registeredGame.game.homeTeamScore &&
-      !registeredGame.game.awayTeamScore
-    ) {
+    if (registeredGame.game.status === "우천취소") {
       return "No game";
     }
-    return "Tie";
+    if (registeredGame.status === "Tie") {
+      return "Tie";
+    }
   };
 
   return (

--- a/src/pages/detail/Detail.tsx
+++ b/src/pages/detail/Detail.tsx
@@ -15,6 +15,7 @@ import styled from "styled-components";
 import Button from "@/components/common/Button";
 import { uploadImg } from "@/utils/uploadImg"; // Import the image upload utility
 import { usePopup } from "@/hooks/usePopup"; // usePopup 사용
+import CheerTeamSelect from "@/components/register/CheerTeamSelect";
 import TextAreaField from "../../components/common/TextAreaField";
 import InputField from "../../components/common/InputField";
 
@@ -25,10 +26,10 @@ const Detail = () => {
 
   const queryClient = useQueryClient();
 
-  const [isEditing, setIsEditing] = useState(false);
+  const [$isEditing, setIsEditing] = useState(false);
   const { openPopup, renderPopup, closePopup } = usePopup(); // usePopup 사용
 
-  const { data } = useQuery({
+  const { data: registeredGame } = useQuery({
     queryKey: ["registeredGame", id],
     queryFn: () => getRegisteredGameById(id),
   });
@@ -71,29 +72,31 @@ const Detail = () => {
   });
 
   const [previewImage, setPreviewImage] = useState<string | null>(
-    data?.image || null,
+    registeredGame?.image || null,
   );
 
   const inputImgRef = useRef<HTMLInputElement>(null);
   const { ref, ...rest } = register("img");
 
   useEffect(() => {
-    if (data) {
+    if (registeredGame) {
       reset({
-        cheeringTeam: data.cheeringTeam.name,
-        seat: data.seat,
-        review: data.review,
+        cheeringTeamId: registeredGame.cheeringTeam.id,
+        cheeringTeamName: registeredGame.cheeringTeam.name,
+        seat: registeredGame.seat,
+        review: registeredGame.review,
       });
-      setPreviewImage(data.image);
+      setPreviewImage(registeredGame.image);
     }
-  }, [data, reset]);
+  }, [registeredGame, reset]);
 
   const onSubmit = (formData: any) => {
     updateMutation.mutate(formData);
+    setIsEditing(!$isEditing);
   };
 
   const handleEdit = () => {
-    setIsEditing(!isEditing);
+    setIsEditing(!$isEditing);
   };
 
   const handleDelete = () => {
@@ -122,12 +125,28 @@ const Detail = () => {
   };
 
   const handleClickImageUpload = () => {
-    if (isEditing) {
+    if ($isEditing) {
       inputImgRef.current?.click();
     }
   };
 
-  if (!data) return null;
+  if (!registeredGame) return null;
+
+  const getResult = () => {
+    if (watch("cheeringTeamId") === undefined) return null;
+    if (registeredGame.game.winningTeam) {
+      return registeredGame.game.winningTeam.id === watch("cheeringTeamId")
+        ? "Win"
+        : "Lose";
+    }
+    if (
+      !registeredGame.game.homeTeamScore &&
+      !registeredGame.game.awayTeamScore
+    ) {
+      return "No game";
+    }
+    return "Tie";
+  };
 
   return (
     <Layout>
@@ -136,13 +155,24 @@ const Detail = () => {
           <Icon icon='IcArrowLeft' onClick={() => navigate(-1)} />
         </div>
         <div>
-          <Text variant='headline'>{`${data.game.date} ${data.game.homeTeam.name} vs ${data.game.awayTeam.name}`}</Text>
+          <Text variant='headline'>{`${registeredGame.game.date} ${registeredGame.game.homeTeam.name} vs ${registeredGame.game.awayTeam.name}`}</Text>
         </div>
         <div>
           <DropDown onEdit={handleEdit} onDelete={handleDelete} />
         </div>
       </Header>
-      <GameListItem className='match' match={data} />
+      <GameListItem
+        className='match'
+        result={getResult() || null} // 서버 API 수정 후, registeredGame.status로 변경
+        isWinningTeam={registeredGame.game.winningTeam}
+        homeTeam={registeredGame.game.homeTeam}
+        homeTeamScore={registeredGame.game.homeTeamScore}
+        awayTeam={registeredGame.game.awayTeam}
+        awayTeamScore={registeredGame.game.awayTeamScore}
+        date={registeredGame.game.date}
+        stadium={registeredGame.game.stadium}
+        status={registeredGame.game.status}
+      />
       <DetailContainer onSubmit={handleSubmit(onSubmit)}>
         <input
           className='img-input'
@@ -153,8 +183,8 @@ const Detail = () => {
           onChange={handleImageChange}
         />
         <ImgUploadContainer
-          isEditing={isEditing}
-          hasImage={!!previewImage}
+          $isEditing={$isEditing}
+          $hasImage={!!previewImage}
           onClick={handleClickImageUpload}>
           {previewImage ? (
             <PreviewImage src={previewImage} alt='직관 사진' />
@@ -165,16 +195,27 @@ const Detail = () => {
             </ImgWrraper>
           )}
         </ImgUploadContainer>
-        <InputField
-          name='cheeringTeam'
-          label='응원팀'
-          type='text'
-          register={register}
-          watch={watch}
-          setValue={setValue}
-          disabled
-          clearable={false}
-        />
+        {$isEditing ? (
+          <CheerTeamSelect
+            homeTeam={registeredGame.game.homeTeam}
+            awayTeam={registeredGame.game.awayTeam}
+            setValue={setValue}
+            watch={watch}
+            name='cheeringTeamId'
+            defaultValue={registeredGame.cheeringTeam.id}
+          />
+        ) : (
+          <InputField
+            name='cheeringTeamName'
+            label='응원팀'
+            type='text'
+            register={register}
+            watch={watch}
+            setValue={setValue}
+            disabled
+            clearable={false}
+          />
+        )}
         <InputField
           name='seat'
           label='좌석'
@@ -182,7 +223,7 @@ const Detail = () => {
           register={register}
           watch={watch}
           setValue={setValue}
-          disabled={!isEditing}
+          disabled={!$isEditing}
           clearable={false}
         />
         <TextAreaField
@@ -191,9 +232,9 @@ const Detail = () => {
           register={register}
           watch={watch}
           setValue={setValue}
-          disabled={!isEditing}
+          disabled={!$isEditing}
         />
-        {isEditing && (
+        {$isEditing && (
           <Button size='big' type='submit'>
             <Text variant='title_02'>수정완료</Text>
           </Button>
@@ -250,19 +291,19 @@ const DetailContainer = styled.form`
 `;
 
 const ImgUploadContainer = styled.label<{
-  hasImage: boolean;
-  isEditing: boolean;
+  $hasImage: boolean;
+  $isEditing: boolean;
 }>`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  border: ${({ hasImage }) =>
-    hasImage ? "none" : "1px dashed var(--gray-200)"};
+  border: ${({ $hasImage }) =>
+    $hasImage ? "none" : "1px dashed var(--gray-200)"};
   border-radius: 12px;
   height: 180px;
   width: 100%;
-  cursor: ${({ isEditing }) => (isEditing ? "pointer" : "default")};
+  cursor: ${({ $isEditing }) => ($isEditing ? "pointer" : "default")};
 `;
 
 const ImgWrraper = styled.div`

--- a/src/pages/register/RegisterForm.tsx
+++ b/src/pages/register/RegisterForm.tsx
@@ -7,19 +7,17 @@ import GameListItem from "@/components/common/GameListItem";
 import styled from "styled-components";
 import { uploadImg } from "@/utils/uploadImg";
 import RegisterFormFields from "@/components/register/RegisterFormFields";
-import { useState } from "react";
 
 const RegisterForm = () => {
   const location = useLocation();
   const { match } = location.state as { match: Game };
   const matchId = match.id;
   const { register, watch, handleSubmit, setValue } = useForm();
-  const [cheeringTeamId, setCheeringTeamId] = useState<number | null>(null);
   const { openPopup, renderPopup, closePopup } = usePopup();
 
   const onSubmit = async (data: any) => {
     try {
-      const { img, seat, review } = data;
+      const { img, seat, review, cheeringTeamId } = data;
       let image = null;
       if (img) {
         image = await uploadImg(img);
@@ -61,14 +59,14 @@ const RegisterForm = () => {
   };
 
   const getResult = () => {
-    if (cheeringTeamId === null) return null;
+    if (watch("cheeringTeamId") === undefined) return null;
     if (match.winningTeam) {
-      return match.winningTeam.id === cheeringTeamId ? "Win" : "Lose";
-    } else if (!match.homeTeamScore && !match.awayTeamScore) {
-      return "No game";
-    } else {
-      return "Tie";
+      return match.winningTeam.id === watch("cheeringTeamId") ? "Win" : "Lose";
     }
+    if (!match.homeTeamScore && !match.awayTeamScore) {
+      return "No game";
+    }
+    return "Tie";
   };
 
   return (
@@ -91,7 +89,6 @@ const RegisterForm = () => {
         setValue={setValue}
         homeTeam={match.homeTeam}
         awayTeam={match.awayTeam}
-        setCheeringTeamId={setCheeringTeamId}
       />
 
       {renderPopup()}

--- a/src/pages/register/RegisterForm.tsx
+++ b/src/pages/register/RegisterForm.tsx
@@ -1,39 +1,28 @@
-import { useLocation } from "react-router-dom";
-import styled from "styled-components";
-import { Game, MyGame } from "@/types/Game";
 import { useForm } from "react-hook-form";
-import TextAreaField from "@/components/common/TextAreaField";
-import Icon from "@/components/common/Icon";
-import Button from "@/components/common/Button";
-import { useImperativeHandle, useRef, useState } from "react";
-import InputField from "@/components/common/InputField";
+import { useLocation } from "react-router-dom";
+import { Game, MyGame } from "@/types/Game";
 import { postRegisterGame } from "@/api/register/register";
-import { uploadImg } from "@/utils/uploadImg";
-import { usePopup } from "@/hooks/usePopup";
 import { useAuthStore } from "@/store/authStore";
-import { getTeamName } from "@/utils/getTeamName";
-import ResultLabel from "@/components/watchList/ListTab/ResultLabel";
-import Text from "../../components/common/Text";
-import { GameListItemContainer } from "../../components/common/GameListItem";
+import { usePopup } from "@/hooks/usePopup";
+import { GameListItemContainer } from "@/components/common/GameListItem";
+import ResultLabel from "@/components/common/ResultLabel";
+import Text from "@/components/common/Text";
+import styled from "styled-components";
+import Icon from "@/components/common/Icon";
+import { uploadImg } from "@/utils/uploadImg";
+import RegisterFormFields from "@/components/register/RegisterFormFields";
 
 const RegisterForm = () => {
   const location = useLocation();
   const { match } = location.state as { match: Game };
   const matchId = match.id;
   const { register, watch, handleSubmit, setValue } = useForm();
-  const inputImgRef = useRef<HTMLInputElement>(null);
-  const { ref, ...rest } = register("img");
-  useImperativeHandle(ref, () => inputImgRef.current);
   const { teamId } = useAuthStore();
-
-  const { openPopup, renderPopup, closePopup } = usePopup(); // 최신 usePopup 사용
-
-  const [previewImage, setPreviewImage] = useState<string | null>(null);
+  const { openPopup, renderPopup, closePopup } = usePopup();
 
   const onSubmit = async (data: any) => {
     try {
       const { img, seat, review } = data;
-
       let image = null;
       if (img.size > 0) {
         image = await uploadImg(img);
@@ -74,33 +63,13 @@ const RegisterForm = () => {
     }
   };
 
-  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { files } = event.target;
-    if (files && files.length > 0) {
-      const file = files[0];
-      const imageUrl = URL.createObjectURL(file);
-      setPreviewImage(imageUrl);
-      setValue("img", file);
-    }
-  };
-
-  const handleClickImageUpload = () => {
-    inputImgRef.current?.click();
-  };
-
   let result = "" as Pick<MyGame, "status">["status"];
-
   if (match.winningTeam) {
-    if (match.winningTeam.id === teamId) {
-      result = "Win";
-    } else {
-      result = "Lose";
-    }
+    result = match.winningTeam.id === teamId ? "Win" : "Lose";
+  } else if (!match.homeTeamScore && !match.awayTeamScore) {
+    result = "No game";
   } else {
     result = "Tie";
-  }
-  if (!match.homeTeamScore && !match.awayTeamScore) {
-    result = "No game";
   }
 
   return (
@@ -127,57 +96,13 @@ const RegisterForm = () => {
         </div>
       </GameListItemContainer>
 
-      <Form onSubmit={handleSubmit(onSubmit)}>
-        <input
-          className='img-input'
-          type='file'
-          accept='image/jpg, image/jpeg, image/png'
-          {...rest}
-          ref={inputImgRef}
-          onChange={handleImageChange}
-        />
+      <RegisterFormFields
+        onSubmit={handleSubmit(onSubmit)}
+        watch={watch}
+        register={register}
+        setValue={setValue}
+      />
 
-        <ImgUploadContainer
-          hasImage={!!previewImage}
-          onClick={handleClickImageUpload}>
-          {previewImage ? (
-            <PreviewImage src={previewImage} alt='직관 사진' />
-          ) : (
-            <ImgWrraper>
-              <Icon icon='IcCamera' width={24} height={24} />
-              <Text variant='caption'>직관 사진을 업로드해주세요</Text>
-            </ImgWrraper>
-          )}
-        </ImgUploadContainer>
-        <InputField
-          label='응원팀'
-          setValue={setValue}
-          register={register}
-          watch={watch}
-          name='cheerTeam'
-          type='input'
-          disabled
-          value={getTeamName(teamId)}
-        />
-        <InputField
-          label='좌석'
-          placeholder='123존 12열 1번'
-          setValue={setValue}
-          register={register}
-          watch={watch}
-          name='seat'
-          type='input'
-        />
-        <TextAreaField
-          label='메모'
-          placeholder='직관 한 마디!'
-          setValue={setValue}
-          register={register}
-          watch={watch}
-          name='review'
-        />
-        <Button size='big'>직관 기록 하기</Button>
-      </Form>
       {renderPopup()}
     </RegisterFormContainer>
   );
@@ -185,48 +110,6 @@ const RegisterForm = () => {
 
 const RegisterFormContainer = styled.div`
   padding-bottom: 80px;
-  .img-input {
-    display: none;
-  }
-`;
-
-const ImgUploadContainer = styled.label<{ hasImage: boolean }>`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  border: ${({ hasImage }) =>
-    hasImage ? "none" : "1px dashed var(--gray-200)"};
-  border-radius: 12px;
-  height: 180px;
-  width: 100%;
-  cursor: pointer;
-`;
-
-const ImgWrraper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  color: var(--gray-200);
-  gap: 10px;
-
-  svg {
-    fill: var(--gray-200);
-  }
-`;
-
-const Form = styled.form`
-  display: flex;
-  flex-direction: column;
-  padding: 32px 20px;
-  gap: 20px;
-`;
-
-const PreviewImage = styled.img`
-  width: 100%;
-  height: 100%;
-  border-radius: 12px;
-  object-fit: cover;
 `;
 
 export default RegisterForm;

--- a/src/pages/register/SelectMatch.tsx
+++ b/src/pages/register/SelectMatch.tsx
@@ -57,13 +57,16 @@ const SelectMatch = () => {
       />
 
       {renderMatches()}
-      <Button
-        className='button'
-        onClick={handleClickButton}
-        disabled={!selectedMatch}
-        size='big'>
-        직관 기록 하기
-      </Button>
+
+      {selectedMatch && (
+        <Button
+          className='button'
+          onClick={handleClickButton}
+          disabled={!selectedMatch}
+          size='big'>
+          직관 기록 하기
+        </Button>
+      )}
     </SelectMatchContainer>
   );
 };
@@ -72,19 +75,19 @@ const SelectMatchContainer = styled.div`
   height: 100%;
   padding-top: 20px;
   position: relative;
-  .button {
-    position: absolute;
-    bottom: 0;
-  }
+
   .loading {
     margin-top: 20px;
   }
+
   .calendar {
     .selected {
       background: ${({ theme }) => theme.colors.primary};
       color: var(--white);
       border-radius: 50%;
     }
+  }
+  .button {
   }
 `;
 

--- a/src/types/Game.ts
+++ b/src/types/Game.ts
@@ -12,7 +12,7 @@ export interface Game {
   id: string;
   date: string;
   time: string;
-  status: string;
+  status: "경기중" | "경기전" | "경기종료" | "우천취소";
   homeTeam: Team;
   awayTeam: Team;
   stadium: {

--- a/src/types/Game.ts
+++ b/src/types/Game.ts
@@ -35,4 +35,4 @@ export interface Team {
   name: string;
 }
 
-export type GameStatus = "All" | "Win" | "Lose" | "Tie" | "No game";
+export type GameStatus = "All" | "Win" | "Lose" | "Tie" | "No game" | null;


### PR DESCRIPTION

## 🤷‍♂️ Description

직관 등록 폼을 컴포넌트화하고, 경기 결과 라벨을 공통 컴포넌트로 이동시켜 UI 재사용성을 높였습니다. 또한 응원팀 선택에 따라 경기 결과 라벨이 동적으로 변경되도록 수정하였고, 세부 페이지에서 응원팀 변경 기능을 추가했습니다.

## 📝 Primary Commits

- [x] 경기 결과 라벨 공통 컴포넌트로 이동
- [x] 직관 등록 폼 컴포넌트화
- [x] 직관 기록에서 모든 경기 선택 가능하게 수정
- [x] 경기 정보와 경기 결과 라벨 리팩토링
- [x] 응원팀에 따라 경기 결과 라벨 변경
- [x] 응원팀 선택에서 default prop 추가
- [x] 세부 페이지에서 응원팀 변경 가능하게 수정
- [x] 코드 정리 및 타입 수정

closes #266 
